### PR TITLE
Merge: Cannot add metadata if person with empty URI is present (#311)

### DIFF
--- a/Goobi/src/de/sub/goobi/metadaten/Metadaten.java
+++ b/Goobi/src/de/sub/goobi/metadaten/Metadaten.java
@@ -399,7 +399,7 @@ public class Metadaten {
 	 */
 	static String[] parseAuthorityFileArgs(String valueURI) {
 		String authority = null, authorityURI = null;
-		if (valueURI != null) {
+		if (valueURI != null && !valueURI.isEmpty()) {
 			int boundary = valueURI.indexOf('#');
 			if (boundary == -1) {
 				boundary = valueURI.lastIndexOf('/');


### PR DESCRIPTION
Bug fix for bug #311