### PR TITLE
Fix name of Goobi e.V. in headers

### DIFF
--- a/Goobi/WEB-INF/reverse-proxy.xml
+++ b/Goobi/WEB-INF/reverse-proxy.xml
@@ -3,7 +3,7 @@
  * This file is part of the Goobi Application - a Workflow tool for the support
  * of mass digitization.
  * 
- * (c) 2014 Goobi. Digialisieren im Verein e.V. &lt;contact@goobi.org&gt;
+ * (c) 2014 Goobi. Digitalisieren im Verein e.V. <contact@goobi.org>
  * 
  * Visit the websites for more information.
  *     		- http://www.goobi.org/en/

--- a/Goobi/css/system/goobi.css
+++ b/Goobi/css/system/goobi.css
@@ -2,7 +2,7 @@
  * This file is part of the Goobi Application - a Workflow tool for the support
  * of mass digitization.
  * 
- * (c) 2013 Goobi. Digialisieren im Verein e.V. &lt;contact@goobi.org&gt;
+ * (c) 2013 Goobi. Digitalisieren im Verein e.V. <contact@goobi.org>
  * 
  * Visit the websites for more information.
  *     		- http://www.goobi.org/en/

--- a/Goobi/newpages/calendar.jsp
+++ b/Goobi/newpages/calendar.jsp
@@ -9,7 +9,7 @@
 	This file is part of the Goobi Application - a Workflow tool for the support
 	of mass digitization.
 	
-	(c) 2013 Goobi. Digialisieren im Verein e.V. &lt;contact@goobi.org&gt;
+	(c) 2013 Goobi. Digitalisieren im Verein e.V. <contact@goobi.org>
 	
 	Visit the websites for more information.
 	    		- http://www.goobi.org/en/

--- a/Goobi/newpages/granularity.jsp
+++ b/Goobi/newpages/granularity.jsp
@@ -7,7 +7,7 @@
 	This file is part of the Goobi Application - a Workflow tool for the support
 	of mass digitization.
 	
-	(c) 2013 Goobi. Digialisieren im Verein e.V. &lt;contact@goobi.org&gt;
+	(c) 2013 Goobi. Digitalisieren im Verein e.V. <contact@goobi.org>
 	
 	Visit the websites for more information.
 	    		- http://www.goobi.org/en/

--- a/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/FindResult.java
+++ b/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/FindResult.java
@@ -2,7 +2,7 @@
  * This file is part of the Goobi Application - a Workflow tool for the support
  * of mass digitization.
  * 
- * (c) 2014 Goobi. Digialisieren im Verein e.V. &lt;contact@goobi.org&gt;
+ * (c) 2014 Goobi. Digitalisieren im Verein e.V. <contact@goobi.org>
  * 
  * Visit the websites for more information.
  *     		- http://www.goobi.org/en/

--- a/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/PicaPlugin.java
+++ b/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/PicaPlugin.java
@@ -2,7 +2,7 @@
  * This file is part of the Goobi Application - a Workflow tool for the support
  * of mass digitization.
  * 
- * (c) 2014 Goobi. Digialisieren im Verein e.V. &lt;contact@goobi.org&gt;
+ * (c) 2014 Goobi. Digitalisieren im Verein e.V. <contact@goobi.org>
  * 
  * Visit the websites for more information.
  *     		- http://www.goobi.org/en/

--- a/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/package-info.java
+++ b/Goobi/plugins/opac/PicaPlugin/org/goobi/production/plugin/CataloguePlugin/PicaPlugin/package-info.java
@@ -2,7 +2,7 @@
  * This file is part of the Goobi Application - a Workflow tool for the support
  * of mass digitization.
  * 
- * (c) 2014 Goobi. Digialisieren im Verein e.V. &lt;contact@goobi.org&gt;
+ * (c) 2014 Goobi. Digitalisieren im Verein e.V. <contact@goobi.org>
  * 
  * Visit the websites for more information.
  *     		- http://www.goobi.org/en/

--- a/Goobi/src/de/sub/goobi/beans/Batch.hbm.xml
+++ b/Goobi/src/de/sub/goobi/beans/Batch.hbm.xml
@@ -3,7 +3,7 @@
  * This file is part of the Goobi Application - a Workflow tool for the support
  * of mass digitization.
  * 
- * (c) 2014 Goobi. Digialisieren im Verein e.V. &lt;contact@goobi.org&gt;
+ * (c) 2014 Goobi. Digitalisieren im Verein e.V. <contact@goobi.org>
  * 
  * Visit the websites for more information.
  *     		- http://www.goobi.org/en/

--- a/Goobi/src/de/sub/goobi/beans/Batch.java
+++ b/Goobi/src/de/sub/goobi/beans/Batch.java
@@ -2,7 +2,7 @@
  * This file is part of the Goobi Application - a Workflow tool for the support
  * of mass digitization.
  *
- * (c) 2014 Goobi. Digialisieren im Verein e.V. &lt;contact@goobi.org&gt;
+ * (c) 2014 Goobi. Digitalisieren im Verein e.V. <contact@goobi.org>
  *
  * Visit the websites for more information.
  *     		- http://www.goobi.org/en/

--- a/Goobi/src/de/sub/goobi/forms/CalendarForm.java
+++ b/Goobi/src/de/sub/goobi/forms/CalendarForm.java
@@ -2,7 +2,7 @@
  * This file is part of the Goobi Application - a Workflow tool for the support
  * of mass digitization.
  * 
- * (c) 2013 Goobi. Digialisieren im Verein e.V. &lt;contact@goobi.org&gt;
+ * (c) 2013 Goobi. Digitalisieren im Verein e.V. <contact@goobi.org>
  * 
  * Visit the websites for more information.
  *     		- http://www.goobi.org/en/

--- a/Goobi/src/de/sub/goobi/forms/GranularityForm.java
+++ b/Goobi/src/de/sub/goobi/forms/GranularityForm.java
@@ -2,7 +2,7 @@
  * This file is part of the Goobi Application - a Workflow tool for the support
  * of mass digitization.
  *
- * (c) 2013 Goobi. Digialisieren im Verein e.V. &lt;contact@goobi.org&gt;
+ * (c) 2013 Goobi. Digitalisieren im Verein e.V. <contact@goobi.org>
  *
  * Visit the websites for more information.
  *     		- http://www.goobi.org/en/

--- a/Goobi/src/de/sub/goobi/helper/ArrayListMap.java
+++ b/Goobi/src/de/sub/goobi/helper/ArrayListMap.java
@@ -2,7 +2,7 @@
  * This file is part of the Goobi Application - a Workflow tool for the support
  * of mass digitization.
  * 
- * (c) 2014 Goobi. Digialisieren im Verein e.V. &lt;contact@goobi.org&gt;
+ * (c) 2014 Goobi. Digitalisieren im Verein e.V. <contact@goobi.org>
  * 
  * Visit the websites for more information.
  *     		- http://www.goobi.org/en/

--- a/Goobi/src/de/sub/goobi/helper/DateUtils.java
+++ b/Goobi/src/de/sub/goobi/helper/DateUtils.java
@@ -2,7 +2,7 @@
  * This file is part of the Goobi Application - a Workflow tool for the support
  * of mass digitization.
  * 
- * (c) 2013 Goobi. Digialisieren im Verein e.V. &lt;contact@goobi.org&gt;
+ * (c) 2013 Goobi. Digitalisieren im Verein e.V. <contact@goobi.org>
  * 
  * Visit the websites for more information.
  *     		- http://www.goobi.org/en/

--- a/Goobi/src/de/sub/goobi/helper/FacesUtils.java
+++ b/Goobi/src/de/sub/goobi/helper/FacesUtils.java
@@ -2,7 +2,7 @@
  * This file is part of the Goobi Application - a Workflow tool for the support
  * of mass digitization.
  * 
- * (c) 2013 Goobi. Digialisieren im Verein e.V. &lt;contact@goobi.org&gt;
+ * (c) 2013 Goobi. Digitalisieren im Verein e.V. <contact@goobi.org>
  * 
  * Visit the websites for more information.
  *     		- http://www.goobi.org/en/

--- a/Goobi/src/de/sub/goobi/helper/XMLUtils.java
+++ b/Goobi/src/de/sub/goobi/helper/XMLUtils.java
@@ -2,7 +2,7 @@
  * This file is part of the Goobi Application - a Workflow tool for the support
  * of mass digitization.
  * 
- * (c) 2013 Goobi. Digialisieren im Verein e.V. &lt;contact@goobi.org&gt;
+ * (c) 2013 Goobi. Digitalisieren im Verein e.V. <contact@goobi.org>
  * 
  * Visit the websites for more information.
  *     		- http://www.goobi.org/en/

--- a/Goobi/src/de/sub/goobi/helper/tasks/CreateNewspaperProcessesTask.java
+++ b/Goobi/src/de/sub/goobi/helper/tasks/CreateNewspaperProcessesTask.java
@@ -2,7 +2,7 @@
  * This file is part of the Goobi Application - a Workflow tool for the support
  * of mass digitization.
  *
- * (c) 2014 Goobi. Digialisieren im Verein e.V. &lt;contact@goobi.org&gt;
+ * (c) 2014 Goobi. Digitalisieren im Verein e.V. <contact@goobi.org>
  *
  * Visit the websites for more information.
  *     		- http://www.goobi.org/en/

--- a/Goobi/src/de/sub/goobi/helper/tasks/EmptyTask.java
+++ b/Goobi/src/de/sub/goobi/helper/tasks/EmptyTask.java
@@ -2,7 +2,7 @@
  * This file is part of the Goobi Application - a Workflow tool for the support
  * of mass digitization.
  * 
- * (c) 2014 Goobi. Digialisieren im Verein e.V. &lt;contact@goobi.org&gt;
+ * (c) 2014 Goobi. Digitalisieren im Verein e.V. <contact@goobi.org>
  * 
  * Visit the websites for more information.
  *     		- http://www.goobi.org/en/

--- a/Goobi/src/de/sub/goobi/helper/tasks/ExportDmsTask.java
+++ b/Goobi/src/de/sub/goobi/helper/tasks/ExportDmsTask.java
@@ -2,7 +2,7 @@
  * This file is part of the Goobi Application - a Workflow tool for the support
  * of mass digitization.
  * 
- * (c) 2014 Goobi. Digialisieren im Verein e.V. &lt;contact@goobi.org&gt;
+ * (c) 2014 Goobi. Digitalisieren im Verein e.V. <contact@goobi.org>
  * 
  * Visit the websites for more information.
  *     		- http://www.goobi.org/en/

--- a/Goobi/src/de/sub/goobi/helper/tasks/ExportNewspaperBatchTask.java
+++ b/Goobi/src/de/sub/goobi/helper/tasks/ExportNewspaperBatchTask.java
@@ -2,7 +2,7 @@
  * This file is part of the Goobi Application - a Workflow tool for the support
  * of mass digitization.
  * 
- * (c) 2014 Goobi. Digialisieren im Verein e.V. &lt;contact@goobi.org&gt;
+ * (c) 2014 Goobi. Digitalisieren im Verein e.V. <contact@goobi.org>
  * 
  * Visit the websites for more information.
  *     		- http://www.goobi.org/en/

--- a/Goobi/src/de/sub/goobi/helper/tasks/TaskManager.java
+++ b/Goobi/src/de/sub/goobi/helper/tasks/TaskManager.java
@@ -2,7 +2,7 @@
  * This file is part of the Goobi Application - a Workflow tool for the support
  * of mass digitization.
  * 
- * (c) 2014 Goobi. Digialisieren im Verein e.V. &lt;contact@goobi.org&gt;
+ * (c) 2014 Goobi. Digitalisieren im Verein e.V. <contact@goobi.org>
  * 
  * Visit the websites for more information.
  *     		- http://www.goobi.org/en/

--- a/Goobi/src/de/sub/goobi/helper/tasks/TaskState.java
+++ b/Goobi/src/de/sub/goobi/helper/tasks/TaskState.java
@@ -2,7 +2,7 @@
  * This file is part of the Goobi Application - a Workflow tool for the support
  * of mass digitization.
  * 
- * (c) 2014 Goobi. Digialisieren im Verein e.V. &lt;contact@goobi.org&gt;
+ * (c) 2014 Goobi. Digitalisieren im Verein e.V. <contact@goobi.org>
  * 
  * Visit the websites for more information.
  *     		- http://www.goobi.org/en/

--- a/Goobi/src/de/sub/goobi/persistence/BatchDAO.java
+++ b/Goobi/src/de/sub/goobi/persistence/BatchDAO.java
@@ -2,7 +2,7 @@
  * This file is part of the Goobi Application - a Workflow tool for the support
  * of mass digitization.
  * 
- * (c) 2014 Goobi. Digialisieren im Verein e.V. &lt;contact@goobi.org&gt;
+ * (c) 2014 Goobi. Digitalisieren im Verein e.V. <contact@goobi.org>
  * 
  * Visit the websites for more information.
  *     		- http://www.goobi.org/en/

--- a/Goobi/src/org/goobi/production/constants/FileNames.java
+++ b/Goobi/src/org/goobi/production/constants/FileNames.java
@@ -2,7 +2,7 @@
  * This file is part of the Goobi Application - a Workflow tool for the support
  * of mass digitization.
  * 
- * (c) 2014 Goobi. Digialisieren im Verein e.V. &lt;contact@goobi.org&gt;
+ * (c) 2014 Goobi. Digitalisieren im Verein e.V. <contact@goobi.org>
  * 
  * Visit the websites for more information.
  *     		- http://www.goobi.org/en/

--- a/Goobi/src/org/goobi/production/constants/Parameters.java
+++ b/Goobi/src/org/goobi/production/constants/Parameters.java
@@ -2,7 +2,7 @@
  * This file is part of the Goobi Application - a Workflow tool for the support
  * of mass digitization.
  * 
- * (c) 2014 Goobi. Digialisieren im Verein e.V. &lt;contact@goobi.org&gt;
+ * (c) 2014 Goobi. Digitalisieren im Verein e.V. <contact@goobi.org>
  * 
  * Visit the websites for more information.
  *     		- http://www.goobi.org/en/

--- a/Goobi/src/org/goobi/production/model/bibliography/Citation.java
+++ b/Goobi/src/org/goobi/production/model/bibliography/Citation.java
@@ -2,7 +2,7 @@
  * This file is part of the Goobi Application - a Workflow tool for the support
  * of mass digitization.
  * 
- * (c) 2014 Goobi. Digialisieren im Verein e.V. &lt;contact@goobi.org&gt;
+ * (c) 2014 Goobi. Digitalisieren im Verein e.V. <contact@goobi.org>
  * 
  * Visit the websites for more information.
  *     		- http://www.goobi.org/en/

--- a/Goobi/src/org/goobi/production/model/bibliography/course/Block.java
+++ b/Goobi/src/org/goobi/production/model/bibliography/course/Block.java
@@ -2,7 +2,7 @@
  * This file is part of the Goobi Application - a Workflow tool for the support
  * of mass digitization.
  * 
- * (c) 2013 Goobi. Digialisieren im Verein e.V. &lt;contact@goobi.org&gt;
+ * (c) 2013 Goobi. Digitalisieren im Verein e.V. <contact@goobi.org>
  * 
  * Visit the websites for more information.
  *     		- http://www.goobi.org/en/

--- a/Goobi/src/org/goobi/production/model/bibliography/course/Course.java
+++ b/Goobi/src/org/goobi/production/model/bibliography/course/Course.java
@@ -2,7 +2,7 @@
  * This file is part of the Goobi Application - a Workflow tool for the support
  * of mass digitization.
  * 
- * (c) 2013 Goobi. Digialisieren im Verein e.V. &lt;contact@goobi.org&gt;
+ * (c) 2013 Goobi. Digitalisieren im Verein e.V. <contact@goobi.org>
  * 
  * Visit the websites for more information.
  *     		- http://www.goobi.org/en/

--- a/Goobi/src/org/goobi/production/model/bibliography/course/CourseToGerman.java
+++ b/Goobi/src/org/goobi/production/model/bibliography/course/CourseToGerman.java
@@ -2,7 +2,7 @@
  * This file is part of the Goobi Application - a Workflow tool for the support
  * of mass digitization.
  * 
- * (c) 2013 Goobi. Digialisieren im Verein e.V. &lt;contact@goobi.org&gt;
+ * (c) 2013 Goobi. Digitalisieren im Verein e.V. <contact@goobi.org>
  * 
  * Visit the websites for more information.
  *     		- http://www.goobi.org/en/

--- a/Goobi/src/org/goobi/production/model/bibliography/course/Granularity.java
+++ b/Goobi/src/org/goobi/production/model/bibliography/course/Granularity.java
@@ -2,7 +2,7 @@
  * This file is part of the Goobi Application - a Workflow tool for the support
  * of mass digitization.
  * 
- * (c) 2013 Goobi. Digialisieren im Verein e.V. &lt;contact@goobi.org&gt;
+ * (c) 2013 Goobi. Digitalisieren im Verein e.V. <contact@goobi.org>
  * 
  * Visit the websites for more information.
  *     		- http://www.goobi.org/en/

--- a/Goobi/src/org/goobi/production/model/bibliography/course/IndividualIssue.java
+++ b/Goobi/src/org/goobi/production/model/bibliography/course/IndividualIssue.java
@@ -2,7 +2,7 @@
  * This file is part of the Goobi Application - a Workflow tool for the support
  * of mass digitization.
  * 
- * (c) 2013 Goobi. Digialisieren im Verein e.V. &lt;contact@goobi.org&gt;
+ * (c) 2013 Goobi. Digitalisieren im Verein e.V. <contact@goobi.org>
  * 
  * Visit the websites for more information.
  *     		- http://www.goobi.org/en/

--- a/Goobi/src/org/goobi/production/model/bibliography/course/Issue.java
+++ b/Goobi/src/org/goobi/production/model/bibliography/course/Issue.java
@@ -2,7 +2,7 @@
  * This file is part of the Goobi Application - a Workflow tool for the support
  * of mass digitization.
  * 
- * (c) 2013 Goobi. Digialisieren im Verein e.V. &lt;contact@goobi.org&gt;
+ * (c) 2013 Goobi. Digitalisieren im Verein e.V. <contact@goobi.org>
  * 
  * Visit the websites for more information.
  *     		- http://www.goobi.org/en/

--- a/Goobi/src/org/goobi/production/model/bibliography/course/package-info.java
+++ b/Goobi/src/org/goobi/production/model/bibliography/course/package-info.java
@@ -2,7 +2,7 @@
  * This file is part of the Goobi Application - a Workflow tool for the support
  * of mass digitization.
  * 
- * (c) 2013 Goobi. Digialisieren im Verein e.V. &lt;contact@goobi.org&gt;
+ * (c) 2013 Goobi. Digitalisieren im Verein e.V. <contact@goobi.org>
  * 
  * Visit the websites for more information.
  *     		- http://www.goobi.org/en/

--- a/Goobi/src/org/goobi/production/plugin/CataloguePlugin/CataloguePlugin.java
+++ b/Goobi/src/org/goobi/production/plugin/CataloguePlugin/CataloguePlugin.java
@@ -2,7 +2,7 @@
  * This file is part of the Goobi Application - a Workflow tool for the support
  * of mass digitization.
  * 
- * (c) 2014 Goobi. Digialisieren im Verein e.V. &lt;contact@goobi.org&gt;
+ * (c) 2014 Goobi. Digitalisieren im Verein e.V. <contact@goobi.org>
  * 
  * Visit the websites for more information.
  *     		- http://www.goobi.org/en/

--- a/Goobi/src/org/goobi/production/plugin/CataloguePlugin/Hit.java
+++ b/Goobi/src/org/goobi/production/plugin/CataloguePlugin/Hit.java
@@ -2,7 +2,7 @@
  * This file is part of the Goobi Application - a Workflow tool for the support
  * of mass digitization.
  * 
- * (c) 2014 Goobi. Digialisieren im Verein e.V. &lt;contact@goobi.org&gt;
+ * (c) 2014 Goobi. Digitalisieren im Verein e.V. <contact@goobi.org>
  * 
  * Visit the websites for more information.
  *     		- http://www.goobi.org/en/

--- a/Goobi/src/org/goobi/production/plugin/CataloguePlugin/QueryBuilder.java
+++ b/Goobi/src/org/goobi/production/plugin/CataloguePlugin/QueryBuilder.java
@@ -2,7 +2,7 @@
  * This file is part of the Goobi Application - a Workflow tool for the support
  * of mass digitization.
  * 
- * (c) 2014 Goobi. Digialisieren im Verein e.V. &lt;contact@goobi.org&gt;
+ * (c) 2014 Goobi. Digitalisieren im Verein e.V. <contact@goobi.org>
  * 
  * Visit the websites for more information.
  *     		- http://www.goobi.org/en/

--- a/Goobi/src/org/goobi/production/plugin/PluginLoader.java
+++ b/Goobi/src/org/goobi/production/plugin/PluginLoader.java
@@ -2,7 +2,7 @@
  * This file is part of the Goobi Application - a Workflow tool for the support
  * of mass digitization.
  * 
- * (c) 2014 Goobi. Digialisieren im Verein e.V. &lt;contact@goobi.org&gt;
+ * (c) 2014 Goobi. Digitalisieren im Verein e.V. <contact@goobi.org>
  * 
  * Visit the websites for more information.
  *     		- http://www.goobi.org/en/

--- a/Goobi/src/org/goobi/production/plugin/UnspecificPlugin.java
+++ b/Goobi/src/org/goobi/production/plugin/UnspecificPlugin.java
@@ -2,7 +2,7 @@
  * This file is part of the Goobi Application - a Workflow tool for the support
  * of mass digitization.
  * 
- * (c) 2014 Goobi. Digialisieren im Verein e.V. &lt;contact@goobi.org&gt;
+ * (c) 2014 Goobi. Digitalisieren im Verein e.V. <contact@goobi.org>
  * 
  * Visit the websites for more information.
  *     		- http://www.goobi.org/en/

--- a/Goobi/test/src/de/sub/goobi/helper/encryption/MD4Test.java
+++ b/Goobi/test/src/de/sub/goobi/helper/encryption/MD4Test.java
@@ -2,7 +2,7 @@
  * This file is part of the Goobi Application - a Workflow tool for the support
  * of mass digitization.
  *
- * (c) 2015 Goobi. Digialisieren im Verein e.V. &lt;contact@goobi.org&gt;
+ * (c) 2015 Goobi. Digitalisieren im Verein e.V. <contact@goobi.org>
  *
  * Visit the websites for more information.
  *     		- http://www.goobi.org/en/

--- a/Goobi/test/src/de/sub/goobi/helper/encryption/MD5Test.java
+++ b/Goobi/test/src/de/sub/goobi/helper/encryption/MD5Test.java
@@ -2,7 +2,7 @@
  * This file is part of the Goobi Application - a Workflow tool for the support
  * of mass digitization.
  *
- * (c) 2015 Goobi. Digialisieren im Verein e.V. &lt;contact@goobi.org&gt;
+ * (c) 2015 Goobi. Digitalisieren im Verein e.V. <contact@goobi.org>
  *
  * Visit the websites for more information.
  *     		- http://www.goobi.org/en/


### PR DESCRIPTION
Replace also the unneeded HTML character entities.

Signed-off-by: Stefan Weil <sw@weilnetz.de>

This typo is even added with new files. The best way to eliminate more copy-and-paste typos
seems to fix all occurrences.
