### PR TITLE
Fix some Javadoc warnings

### DIFF
--- a/Goobi/src/de/sub/goobi/beans/Batch.java
+++ b/Goobi/src/de/sub/goobi/beans/Batch.java
@@ -307,8 +307,7 @@ public class Batch {
 	 *
 	 * @param processes
 	 *            collection containing elements to be removed from this set
-	 * @return whether the set of processes changed as a result of the call
-	 * @returns true if the set of processes was changed as a result of the call
+	 * @return true if the set of processes was changed as a result of the call
 	 */
 	public boolean removeAll(Collection<?> processes) {
 		return getProcesses().removeAll(processes);

--- a/Goobi/src/de/sub/goobi/export/dms/AutomaticDmsExportWithoutHibernate.java
+++ b/Goobi/src/de/sub/goobi/export/dms/AutomaticDmsExportWithoutHibernate.java
@@ -96,8 +96,7 @@ public class AutomaticDmsExportWithoutHibernate extends ExportMetsWithoutHiberna
 	/**
 	 * DMS-Export an eine gewünschte Stelle
 	 * 
-	 * @param myProzess
-	 * @param zielVerzeichnis
+	 * @param process
 	 * @throws InterruptedException
 	 * @throws IOException
 	 * @throws WriteException

--- a/Goobi/src/de/sub/goobi/export/dms/ExportDms.java
+++ b/Goobi/src/de/sub/goobi/export/dms/ExportDms.java
@@ -94,7 +94,7 @@ public class ExportDms extends ExportMets {
 	 * DMS-Export an eine gewünschte Stelle
 	 * 
 	 * @param myProzess
-	 * @param zielVerzeichnis
+	 * @param inZielVerzeichnis
 	 * @throws InterruptedException
 	 * @throws IOException
 	 * @throws WriteException

--- a/Goobi/src/de/sub/goobi/export/download/ExportMets.java
+++ b/Goobi/src/de/sub/goobi/export/download/ExportMets.java
@@ -109,7 +109,7 @@ public class ExportMets {
 	 * DMS-Export an eine gewünschte Stelle
 	 * 
 	 * @param myProzess
-	 * @param zielVerzeichnis
+	 * @param inZielVerzeichnis
 	 * @throws InterruptedException
 	 * @throws IOException
 	 * @throws PreferencesException

--- a/Goobi/src/de/sub/goobi/forms/HelperForm.java
+++ b/Goobi/src/de/sub/goobi/forms/HelperForm.java
@@ -53,6 +53,9 @@ import de.sub.goobi.helper.exceptions.DAOException;
 import de.sub.goobi.persistence.DocketDAO;
 import de.sub.goobi.persistence.RegelsatzDAO;
 
+/**
+ * @author Wulf Riebensahm
+ */
 public class HelperForm {
 
 	public static final String MAIN_JSF_PATH = "/newpages";
@@ -68,8 +71,6 @@ public class HelperForm {
 	}
 
 	/**
-	 * @author Wulf
-	 * @param none
 	 * @return returns dynamically resolved path for Version Logo
 	 */
 	public String getApplicationVersionLogo() {
@@ -233,13 +234,11 @@ public class HelperForm {
 		return myList;
 	}
 
-	/*
+	/**
 	 * method returns a valid css file, which is the suggestion unless
 	 * suggestion is not available if not available default.css is returned
 	 * 
-	 * @author Wulf
-	 * 
-	 * @param suggested css file
+	 * @param cssFileName suggested css file
 	 * 
 	 * @return valid css file
 	 */

--- a/Goobi/src/de/sub/goobi/forms/LoginForm.java
+++ b/Goobi/src/de/sub/goobi/forms/LoginForm.java
@@ -327,7 +327,7 @@ public class LoginForm {
 	 *             If the thread running the script is interrupted by another
 	 *             thread while it is waiting, then the wait is ended and an
 	 *             InterruptedException is thrown.
-	 * @throw IOException If an I/O error occurs.
+	 * @throws IOException if an I/O error occurs.
 	 */
 	public static String getCurrentUserHomeDir() throws IOException, InterruptedException {
 		String result = "";

--- a/Goobi/src/de/sub/goobi/forms/ProjekteForm.java
+++ b/Goobi/src/de/sub/goobi/forms/ProjekteForm.java
@@ -532,7 +532,7 @@ public class ProjekteForm extends BasisForm {
 	}
 
 	/**
-	 * @returns a StatQuestThroughputCommonFlow for the generation of projekt progress data
+	 * @return a StatQuestThroughputCommonFlow for the generation of projekt progress data
 	 */
 	public StatQuestProjectProgressData getProjectProgressInterface() {
 

--- a/Goobi/src/de/sub/goobi/forms/ProzessverwaltungForm.java
+++ b/Goobi/src/de/sub/goobi/forms/ProzessverwaltungForm.java
@@ -115,6 +115,9 @@ import de.sub.goobi.persistence.ProzessDAO;
 import de.sub.goobi.persistence.apache.StepManager;
 import de.sub.goobi.persistence.apache.StepObject;
 
+/**
+ * @author Wulf Riebensahm
+ */
 public class ProzessverwaltungForm extends BasisForm {
 	private static final long serialVersionUID = 2838270843176821134L;
 	private static final Logger logger = Logger.getLogger(ProzessverwaltungForm.class);
@@ -175,7 +178,7 @@ public class ProzessverwaltungForm extends BasisForm {
 	/**
 	 * needed for ExtendedSearch
 	 * 
-	 * @return
+	 * @return always true
 	 */
 	public boolean getInitialize() {
 		return true;
@@ -1413,8 +1416,6 @@ public class ProzessverwaltungForm extends BasisForm {
 	/**
 	 * ist called via jsp at the end of building a chart in include file Prozesse_Liste_Statistik.jsp and resets the statistics so that with the next
 	 * reload a chart is not shown anymore
-	 * 
-	 * @author Wulf
 	 */
 	public String getResetStatistic() {
 		this.showStatistics = false;

--- a/Goobi/src/de/sub/goobi/helper/ProjectHelper.java
+++ b/Goobi/src/de/sub/goobi/helper/ProjectHelper.java
@@ -54,8 +54,8 @@ public class ProjectHelper {
 	 * 
 	 * 
 	 * @param instance
-	 * @returns a GoobiCollection of the following structure:
-	 * @GoobiCollection 1-n representing the steps each step has the following properties @ stepTitle,stepOrder,stepCount,stepImageCount
+	 * @return a GoobiCollection of the following structure:
+	 *  GoobiCollection 1-n representing the steps each step has the following properties @ stepTitle,stepOrder,stepCount,stepImageCount
 	 *                  ,totalProcessCount,totalImageCount which can get extracted by the IGoobiCollection Inteface using the getItem(<name>) method
 	 * 
 	 *                  standard workflow of the project according to the definition that only steps shared by all processes are returned. The

--- a/Goobi/src/de/sub/goobi/helper/exceptions/GUIExceptionWrapper.java
+++ b/Goobi/src/de/sub/goobi/helper/exceptions/GUIExceptionWrapper.java
@@ -238,7 +238,7 @@ public class GUIExceptionWrapper extends Exception {
 
 	/**
 	 * 
-	 * @returns the Class of the initial Exception if possible
+	 * @return the Class of the initial Exception if possible
 	 */
 	private String getContextInfo(){
 		String getContextInfo = "";

--- a/Goobi/src/de/sub/goobi/helper/tasks/TaskManager.java
+++ b/Goobi/src/de/sub/goobi/helper/tasks/TaskManager.java
@@ -54,7 +54,7 @@ import de.sub.goobi.helper.tasks.EmptyTask.Behaviour;
 /**
  * The class TaskManager serves to handle the execution of threads. It can be
  * user controlled by the “Long running task manager”, backed by
- * {@link de.sub.goobi.forms.LongRunningTaskForm}.
+ * {@link de.sub.goobi.forms.LongRunningTasksForm}.
  * 
  * @author Matthias Ronge &lt;matthias.ronge@zeutschel.de&gt;
  */

--- a/Goobi/src/de/sub/goobi/metadaten/MetadatenImagesHelper.java
+++ b/Goobi/src/de/sub/goobi/metadaten/MetadatenImagesHelper.java
@@ -90,7 +90,6 @@ public class MetadatenImagesHelper {
      * number images with existing number of page DocStructs if it is the same don't do anything if DocStructs are less add new pages to
      * physicalDocStruct if images are less delete pages from the end of pyhsicalDocStruct --------------------------------
      * 
-     * @return null
      * @throws TypeNotAllowedForParentException
      * @throws TypeNotAllowedForParentException
      * @throws InterruptedException

--- a/Goobi/src/de/sub/goobi/modul/ExtendedDataImpl.java
+++ b/Goobi/src/de/sub/goobi/modul/ExtendedDataImpl.java
@@ -74,7 +74,10 @@ public class ExtendedDataImpl extends DataImpl {
    
    /**
     * Diese Methode wird benötigt um Metadaten zu schreiben.
-    * @param SessionID, Type, Count, Property
+    * @param sessionId
+    * @param type
+    * @param count
+    * @param pp
     * @return Status (Fehler)
     * @throws GoobiException: 1, 2, 6, 7, 254, 1500, 1501, 1502
     * ================================================================*/
@@ -143,7 +146,9 @@ public int add(String sessionId, String type, int count, HashMap pp) throws Goob
 
    /**
     * Diese Methode wird benötigt um feste Eigenschaften von Metadaten auszulesen.
-    * @param SessionID, Type, Count
+    * @param sessionId
+    * @param type
+    * @param count
     * @return Liste von Namen – Wert Paaren
     * @throws GoobiException: 1, 2, 6, 254, 1500, 1501, 1502
     * ================================================================*/
@@ -191,7 +196,9 @@ public HashMap<String, String> getData(String sessionId, String type, int count)
 
    /**
     * Diese Methode wird benötigt um Eigenschaften von Metadaten auszulesen
-    * @param SessionID, Type, Count
+    * @param sessionId
+    * @param type
+    * @param count
     * @return Liste von Namen – Wert Paaren
     * @throws GoobiException: 1, 2, 6, 254, 1501, 1502
     * ================================================================*/
@@ -252,7 +259,10 @@ public ArrayList<GoobiProcessProperty> getProperties(String sessionId, String ty
 
    /**
     * Diese Methode wird benötigt um Metadaten zu schreiben.
-    * @param SessionID, Type, Count, Property
+    * @param sessionId
+    * @param type
+    * @param count
+    * @param pp
     * @return Status (Fehler)
     * @throws GoobiException: 1, 2, 6, 7, 254, 1501, 1502
     * ================================================================*/

--- a/Goobi/src/de/sub/goobi/modul/ExtendedProzessImpl.java
+++ b/Goobi/src/de/sub/goobi/modul/ExtendedProzessImpl.java
@@ -54,7 +54,7 @@ public class ExtendedProzessImpl extends ProcessImpl {
    /**
     * Diese Methode wird benötigt um die mit der Session ID verbundene Prozess ID zu erhalten. 
     * Die Implementierung dieser Methode ist optional.
-    * @param SessionID
+    * @param sessionID
     * @return ProzessID
     * @throws GoobiException: 1, 2, 4, 5, 6, 254, 1400
     * ================================================================*/
@@ -65,7 +65,7 @@ public class ExtendedProzessImpl extends ProcessImpl {
 
    /**
     * Diese Methode wird benötigt um die Volltextdatei zu erhalten.
-    * @param SessionID
+    * @param sessionId
     * @return Pfad zur XML Datei (String)
     * @throws GoobiException: 1, 2, 4, 5, 6, 254, 1400, 1401
     * ================================================================*/
@@ -86,7 +86,7 @@ public class ExtendedProzessImpl extends ProcessImpl {
 
    /**
     * Diese Methode wird benötigt um das relative Arbeisverzeichnis zu erhalten.
-    * @param SessionID
+    * @param sessionId
     * @return Arbeitsverzeichnis (String)
     * @throws GoobiException: 1, 2, 4, 5, 6, 254, 1400, 1401
     * ================================================================*/
@@ -107,7 +107,7 @@ public class ExtendedProzessImpl extends ProcessImpl {
 
    /**
     * Diese Methode wird benötigt um die Metadatendatei zu erhalten.
-    * @param SessionID
+    * @param sessionId
     * @return Pfad zur XML Datei (String)
     * @throws GoobiException: 1, 2, 4, 5, 6, 254, 1400, 1401
     * ================================================================*/
@@ -129,7 +129,7 @@ public class ExtendedProzessImpl extends ProcessImpl {
    /**
     * Diese Methode wird benutzt um die Parameter für den Aufruf des Moduls zu bekommen. 
     * Die Implementierung dieser Methode ist optional.
-    * @param SessionID
+    * @param sessionId
     * @return Parameter Struktur
     * @throws GoobiException: 1, 2, 4, 5, 6, 254
     * ================================================================*/
@@ -155,7 +155,7 @@ public class ExtendedProzessImpl extends ProcessImpl {
    /**
     * Diese Methode liefert das Projekt eines Prozesses. 
     * Die Implementierung dieser Methode ist optional.
-    * @param SessionID
+    * @param sessionId
     * @return Projekttitel (String)
     * @throws GoobiException: 1, 2, 4, 5, 6, 254, 1400
     * ================================================================*/
@@ -167,7 +167,7 @@ public class ExtendedProzessImpl extends ProcessImpl {
    /**
     * Diese Methode liefert den Titel eines Prozesses. 
     * Die Implementierung dieser Methode ist optional.
-    * @param SessionID
+    * @param sessionId
     * @return Prozesstitel (String)
     * @throws GoobiException: 1, 2, 4, 5, 6, 254, 1400
     * ================================================================*/

--- a/Goobi/src/org/goobi/production/flow/statistics/StatisticsManager.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/StatisticsManager.java
@@ -495,7 +495,7 @@ public class StatisticsManager implements Serializable {
 	}
 
 	/**
-	 * @return includeLoops flag
+	 * @param includeLoops
 	 */
 	public void setIncludeLoops(boolean includeLoops) {
 		this.includeLoops = includeLoops;

--- a/Goobi/src/org/goobi/production/flow/statistics/enums/TimeUnit.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/enums/TimeUnit.java
@@ -151,7 +151,7 @@ public enum TimeUnit {
 	
 	/**
 	 * 
-	 * @returns a day factor for the selected time unit based on an average year of 365.25 days
+	 * @return a day factor for the selected time unit based on an average year of 365.25 days
 	 */
 	public Double getDayFactor(){
 		return this.dayFactor;

--- a/Goobi/src/org/goobi/production/flow/statistics/hibernate/FilterHelper.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/hibernate/FilterHelper.java
@@ -190,7 +190,6 @@ public class FilterHelper {
 	 * 
 	 * @param String
 	 *            parameter
-	 * @author Wulf Riebensahm
 	 * @return Integer
 	 ****************************************************************************/
 	protected static Integer getStepStart(String parameter) {
@@ -203,7 +202,6 @@ public class FilterHelper {
 	 * 
 	 * @param String
 	 *            parameter
-	 * @author Wulf Riebensahm
 	 * @return Integer
 	 ****************************************************************************/
 	protected static Integer getStepEnd(String parameter) {
@@ -217,7 +215,6 @@ public class FilterHelper {
 	 * 
 	 * @param String
 	 *            parameters
-	 * @author Wulf Riebensahm
 	 * @return StepFilter
 	 ****************************************************************************/
 	protected static StepFilter getStepFilter(String parameters) {

--- a/Goobi/src/org/goobi/production/flow/statistics/hibernate/StatQuestProjectProgressData.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/hibernate/StatQuestProjectProgressData.java
@@ -85,7 +85,7 @@ public class StatQuestProjectProgressData implements IStatisticalQuestionLimited
 	 * not included means that only min(date) or max(date) - depending on option
 	 * in
 	 * 
-	 * @see historyEventType
+	 * @see HistoryEventType
 	 * 
 	 * @return status of loops included or not
 	 */

--- a/Goobi/src/org/goobi/production/flow/statistics/hibernate/StatQuestProjectProgressData.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/hibernate/StatQuestProjectProgressData.java
@@ -99,7 +99,7 @@ public class StatQuestProjectProgressData implements IStatisticalQuestionLimited
 
 	/**
 	 * 
-	 * @returns true if all Data for the generation is set
+	 * @return true if all Data for the generation is set
 	 */
 
 	public Boolean isDataComplete() {
@@ -216,7 +216,7 @@ public class StatQuestProjectProgressData implements IStatisticalQuestionLimited
 
 	/**
 	 * 
-	 * @returns if reference curve is used of average production
+	 * @return if reference curve is used of average production
 	 */
 	public Boolean getReferenceCurve() {
 		return this.flagReferenceCurve;
@@ -468,7 +468,7 @@ public class StatQuestProjectProgressData implements IStatisticalQuestionLimited
 
 	/**
 	 * 
-	 * @returns List of Steps that are selectable for this View
+	 * @return List of Steps that are selectable for this View
 	 */
 
 	public List<String> getSelectableSteps() {
@@ -522,8 +522,8 @@ public class StatQuestProjectProgressData implements IStatisticalQuestionLimited
 
 	/**
 	 * 
-	 * @returns DataTable generated from the selected step names and the
-	 *          selected reference curve
+	 * @return DataTable generated from the selected step names and the
+	 *         selected reference curve
 	 */
 	public DataTable getSelectedTable() {
 		getDataTable();

--- a/Goobi/src/org/goobi/production/flow/statistics/hibernate/StatQuestThroughput.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/hibernate/StatQuestThroughput.java
@@ -71,7 +71,7 @@ public class StatQuestThroughput implements IStatisticalQuestionLimitedTimeframe
 	 * not included means that only min(date) or max(date) - depending on option
 	 * in
 	 * 
-	 * @see historyEventType
+	 * @see HistoryEventType
 	 * 
 	 * @return status of loops included or not
 	 */

--- a/Goobi/src/org/goobi/production/plugin/CataloguePlugin/CataloguePlugin.java
+++ b/Goobi/src/org/goobi/production/plugin/CataloguePlugin/CataloguePlugin.java
@@ -350,7 +350,6 @@ public class CataloguePlugin extends UnspecificPlugin {
 	 * 
 	 * @param catalogue
 	 *            catalogue in question
-	 * @return whether the plugin supports that catalogue
 	 */
 	public void useCatalogue(String catalogue) {
 		invokeQuietly(plugin, useCatalogue, catalogue, null);

--- a/build.xml
+++ b/build.xml
@@ -205,7 +205,7 @@
     <!-- building javadoc for sources -->
     <target name="javadoc" depends="init">
         <javadoc destdir="${doc.javadocs.dir}"
-                 sourcepath="${java.src.dir}" Author="true"
+                 sourcepath="${java.src.dir}:${java.src.dubious.dir}" Author="true"
                  version="true"
                  Use="true" noindex="true" Windowtitle="Goobi JavaDoc References" Doctitle="Goobi JavaDoc References"
                  bottom="Copyright 2009, Center for Retrospective Digitization, Göttingen (GDZ)." encoding="UTF8">


### PR DESCRIPTION
These patches reduce the number of warnings from 147 to 96.
They also change the copyright from GDZ to Goobi e.V. (1st patch, can optionally be omitted).