### PR TITLE
Fixes “EmptyTask.clone() does not call super.clone()”

### DIFF
--- a/Goobi/src/de/sub/goobi/helper/ScriptThreadWithoutHibernate.java
+++ b/Goobi/src/de/sub/goobi/helper/ScriptThreadWithoutHibernate.java
@@ -67,7 +67,7 @@ public class ScriptThreadWithoutHibernate extends EmptyTask implements INameable
 			function = "executeAllScriptsForStep";
 		} else if (step.isTypExport()) {
 			function = "executeDmsExport";
-		} else if (step.getStepPlugin() != null && step.getStepPlugin().length() > 0) {
+		} else if ((step.getStepPlugin() != null) && (step.getStepPlugin().length() > 0)) {
 			function = "executeStepPlugin";
 		}
 		List<String> parameterList = new ArrayList<String>(1);
@@ -114,7 +114,7 @@ public class ScriptThreadWithoutHibernate extends EmptyTask implements INameable
 			this.hs.executeAllScriptsForStep(this.step, automatic);
 		} else if (this.step.isTypExport()) {
 			this.hs.executeDmsExport(this.step, automatic);
-		} else if (this.step.getStepPlugin() != null && this.step.getStepPlugin().length() > 0) {
+		} else if ((this.step.getStepPlugin() != null) && (this.step.getStepPlugin().length() > 0)) {
 			IStepPlugin isp = (IStepPlugin) PluginLoader.getPluginByTitle(PluginType.Step, step.getStepPlugin());
 			isp.initialize(step, "");
 			if (isp.execute()) {
@@ -124,14 +124,15 @@ public class ScriptThreadWithoutHibernate extends EmptyTask implements INameable
 	}
 
 	/**
-	 * The function clone() calls the clone constructor to create a new instance
-	 * of this object. This is necessary for Threads that have terminated in
-	 * order to render to run them again possible.
+	 * Calls the clone constructor to create a not yet executed instance of this
+	 * thread object. This is necessary for threads that have terminated in
+	 * order to render possible to restart them.
 	 * 
-	 * @see de.sub.goobi.helper.tasks.EmptyTask#clone()
+	 * @return a not-yet-executed replacement of this thread
+	 * @see de.sub.goobi.helper.tasks.EmptyTask#replace()
 	 */
 	@Override
-	public ScriptThreadWithoutHibernate clone() {
+	public ScriptThreadWithoutHibernate replace() {
 		return new ScriptThreadWithoutHibernate(this);
 	}
 }

--- a/Goobi/src/de/sub/goobi/helper/tasks/CreateNewspaperProcessesTask.java
+++ b/Goobi/src/de/sub/goobi/helper/tasks/CreateNewspaperProcessesTask.java
@@ -242,17 +242,17 @@ public class CreateNewspaperProcessesTask extends EmptyTask implements INameable
 					addToBatches(newProcess.getProzessKopie(), issues, currentTitle);
 				}
 				nextProcessToCreate++;
-				setProgress(100 * nextProcessToCreate / (numberOfProcesses + 2));
+				setProgress((100 * nextProcessToCreate) / (numberOfProcesses + 2));
 				if (isInterrupted()) {
 					return;
 				}
 			}
 			flushLogisticsBatch(currentTitle);
-			setProgress((100 * nextProcessToCreate + 1) / (numberOfProcesses + 2));
+			setProgress(((100 * nextProcessToCreate) + 1) / (numberOfProcesses + 2));
 			saveFullBatch(currentTitle);
 			setProgress(100);
 		} catch (Exception e) { // ReadException, PreferencesException, SwapException, DAOException, WriteException, IOException, InterruptedException from ProzesskopieForm.NeuenProzessAnlegen()
-			String message = e instanceof MetadataTypeNotAllowedException && currentTitle != null ? Helper
+			String message = (e instanceof MetadataTypeNotAllowedException) && (currentTitle != null) ? Helper
 					.getTranslation("CreateNewspaperProcessesTask.MetadataNotAllowedException",
 							Arrays.asList(new String[] { currentTitle })) : e.getClass().getSimpleName()
 					+ (currentTitle != null ? " while creating " + currentTitle : " in CreateNewspaperProcessesTask");
@@ -374,7 +374,7 @@ public class CreateNewspaperProcessesTask extends EmptyTask implements INameable
 			// create the issue
 			DocStruct issue = createFirstChild(day, document, ruleset);
 			String heading = individualIssue.getHeading();
-			if (heading != null && heading.trim().length() > 0) {
+			if ((heading != null) && (heading.trim().length() > 0)) {
 				addMetadatum(issue, issue.getType().getName(), heading, true);
 			}
 			addMetadatum(issue, year.getType().getName(), theYear, false);
@@ -435,7 +435,7 @@ public class CreateNewspaperProcessesTask extends EmptyTask implements INameable
 		if (createBatches != null) {
 			int lastIndex = issues.size() - 1;
 			int breakMark = issues.get(lastIndex).getBreakMark(createBatches);
-			if (currentBreakMark != null && breakMark != currentBreakMark) {
+			if ((currentBreakMark != null) && (breakMark != currentBreakMark)) {
 				flushLogisticsBatch(processTitle);
 			}
 			if (batchLabel == null) {
@@ -515,14 +515,15 @@ public class CreateNewspaperProcessesTask extends EmptyTask implements INameable
 	}
 
 	/**
-	 * The function clone() creates a copy of this CreateNewspaperProcessesTask
-	 * for providing the possibility to restart it because a Thread can only be
-	 * started once.
+	 * Calls the clone constructor to create a not yet executed instance of this
+	 * thread object. This is necessary for threads that have terminated in
+	 * order to render possible to restart them.
 	 * 
-	 * @see de.sub.goobi.helper.tasks.EmptyTask#clone()
+	 * @return a not-yet-executed replacement of this thread
+	 * @see de.sub.goobi.helper.tasks.EmptyTask#replace()
 	 */
 	@Override
-	public CreateNewspaperProcessesTask clone() {
+	public CreateNewspaperProcessesTask replace() {
 		return new CreateNewspaperProcessesTask(this);
 	}
 

--- a/Goobi/src/de/sub/goobi/helper/tasks/CreatePdfFromServletThread.java
+++ b/Goobi/src/de/sub/goobi/helper/tasks/CreatePdfFromServletThread.java
@@ -92,7 +92,7 @@ public class CreatePdfFromServletThread extends LongRunningTask {
 	@Override
 	public void run() {
 		setStatusProgress(30);
-		if (this.getProzess() == null || this.targetFolder == null || this.internalServletPath == null) {
+		if ((this.getProzess() == null) || (this.targetFolder == null) || (this.internalServletPath == null)) {
 			setStatusMessage("parameters for temporary and final folder and internal servlet path not defined");
 			setStatusProgress(-1);
 			return;
@@ -114,9 +114,9 @@ public class CreatePdfFromServletThread extends LongRunningTask {
 			 * --------------------------------*/
 
 			
-			if (new MetadatenVerifizierung().validate(this.getProzess()) && this.metsURL != null) {
+			if (new MetadatenVerifizierung().validate(this.getProzess()) && (this.metsURL != null)) {
 				/* if no contentserverurl defined use internal goobiContentServerServlet */
-					if (contentServerUrl == null || contentServerUrl.length() == 0) {
+					if ((contentServerUrl == null) || (contentServerUrl.length() == 0)) {
 						contentServerUrl = this.internalServletPath + "/gcs/gcs?action=pdf&metsFile=";
 					}
 				goobiContentServerUrl = new URL(contentServerUrl + this.metsURL);		
@@ -126,7 +126,7 @@ public class CreatePdfFromServletThread extends LongRunningTask {
 				 * --------------------------------*/
 				
 			} else {
-				if (contentServerUrl == null || contentServerUrl.length() == 0) {
+				if ((contentServerUrl == null) || (contentServerUrl.length() == 0)) {
 					contentServerUrl = this.internalServletPath + "/cs/cs?action=pdf&images=";
 				}
 				String url = "";
@@ -169,7 +169,7 @@ public class CreatePdfFromServletThread extends LongRunningTask {
 			FileOutputStream fos = new FileOutputStream(tempPdf);
 			byte[] bytes = new byte[8192];
 			int count = bis.read(bytes);
-			while (count != -1 && count <= 8192) {
+			while ((count != -1) && (count <= 8192)) {
 				fos.write(bytes, 0, count);
 				count = bis.read(bytes);
 			}
@@ -252,14 +252,15 @@ public class CreatePdfFromServletThread extends LongRunningTask {
 	}
 
 	/**
-	 * The function clone() calls the clone constructor to create a new instance
-	 * of this object. This is necessary for Threads that have terminated in
-	 * order to render to run them again possible.
+	 * Calls the clone constructor to create a not yet executed instance of this
+	 * thread object. This is necessary for threads that have terminated in
+	 * order to render possible to restart them.
 	 * 
-	 * @see de.sub.goobi.helper.tasks.EmptyTask#clone()
+	 * @return a not-yet-executed replacement of this thread
+	 * @see de.sub.goobi.helper.tasks.EmptyTask#replace()
 	 */
 	@Override
-	public CreatePdfFromServletThread clone() {
+	public CreatePdfFromServletThread replace() {
 		return new CreatePdfFromServletThread(this);
 	}
 

--- a/Goobi/src/de/sub/goobi/helper/tasks/EmptyTask.java
+++ b/Goobi/src/de/sub/goobi/helper/tasks/EmptyTask.java
@@ -54,7 +54,7 @@ import de.sub.goobi.helper.Helper;
  * 
  * @author Matthias Ronge &lt;matthias.ronge@zeutschel.de&gt;
  */
-public class EmptyTask extends Thread implements Cloneable, INameableTask {
+public class EmptyTask extends Thread implements INameableTask {
 	/**
 	 * The enum Actions lists the available instructions to the housekeeper what
 	 * to do with a terminated thread. These are:
@@ -170,15 +170,14 @@ public class EmptyTask extends Thread implements Cloneable, INameableTask {
 	}
 
 	/**
-	 * The method clone does call the copy constructor to create a copy of that
-	 * object. Every subclass that has fields must provide its own copy
+	 * Calls the copy constructor to create a not-yet-executed replacement copy
+	 * of that thread object. Every subclass must provide its own copy
 	 * constructor—which must call super(objectToCopy)—and overload this method
 	 * to call its own copy constructor.
 	 * 
-	 * @see java.lang.Thread#clone()
+	 * @return a not-yet-executed replacement of this thread
 	 */
-	@Override
-	public EmptyTask clone() {
+	public EmptyTask replace() {
 		return new EmptyTask(this);
 	}
 

--- a/Goobi/src/de/sub/goobi/helper/tasks/ExportDmsTask.java
+++ b/Goobi/src/de/sub/goobi/helper/tasks/ExportDmsTask.java
@@ -114,13 +114,15 @@ public class ExportDmsTask extends EmptyTask implements INameableTask {
 	}
 
 	/**
-	 * The function clone() provides the ability to copy the task object to
-	 * restart an export that was previously interrupted by the user.
+	 * Calls the clone constructor to create a not yet executed instance of this
+	 * thread object. This is necessary for threads that have terminated in
+	 * order to render possible to restart them.
 	 * 
-	 * @see de.sub.goobi.helper.tasks.EmptyTask#clone()
+	 * @return a not-yet-executed replacement of this thread
+	 * @see de.sub.goobi.helper.tasks.EmptyTask#replace()
 	 */
 	@Override
-	public ExportDmsTask clone() {
+	public ExportDmsTask replace() {
 		return new ExportDmsTask(this);
 	}
 }

--- a/Goobi/src/de/sub/goobi/helper/tasks/ExportNewspaperBatchTask.java
+++ b/Goobi/src/de/sub/goobi/helper/tasks/ExportNewspaperBatchTask.java
@@ -253,11 +253,11 @@ public class ExportNewspaperBatchTask extends EmptyTask implements INameableTask
 					}
 					MetsMods extendedData = buildExportableMetsMods(process = processesIterator.next(),
 							collectedYears, aggregation);
-					setProgress(GAUGE_INCREMENT_PER_ACTION + ++dividend / divisor);
+					setProgress(GAUGE_INCREMENT_PER_ACTION + (++dividend / divisor));
 
 					new ExportDms(ConfigMain.getBooleanParameter(Parameters.EXPORT_WITH_IMAGES, true)).startExport(
 							process, LoginForm.getCurrentUserHomeDir(), extendedData.getDigitalDocument());
-					setProgress(GAUGE_INCREMENT_PER_ACTION + ++dividend / divisor);
+					setProgress(GAUGE_INCREMENT_PER_ACTION + (++dividend / divisor));
 				}
 			}
 		} catch (Exception e) { // PreferencesException, ReadException, SwapException, DAOException, IOException, InterruptedException and some runtime exceptions
@@ -656,7 +656,7 @@ public class ExportNewspaperBatchTask extends EmptyTask implements INameableTask
 			int currentYear, String ownMetsPointerURL, DigitalDocument act, Prefs ruleSet)
 			throws TypeNotAllowedForParentException, TypeNotAllowedAsChildException, MetadataTypeNotAllowedException {
 		for (int i = 0; i < issues.size(); i++) {
-			if (issues.getKey(i).getYear() == currentYear && !issues.getValue(i).equals(ownMetsPointerURL)) {
+			if ((issues.getKey(i).getYear() == currentYear) && !issues.getValue(i).equals(ownMetsPointerURL)) {
 				insertIssueReference(act, ruleSet, issues.getKey(i), issues.getValue(i));
 			}
 		}
@@ -701,14 +701,15 @@ public class ExportNewspaperBatchTask extends EmptyTask implements INameableTask
 	}
 
 	/**
-	 * The function clone() creates a copy of this ExportNewspaperBatchTask for
-	 * providing the possibility to restart it because a Thread can only be
-	 * started once.
+	 * Calls the clone constructor to create a not yet executed instance of this
+	 * thread object. This is necessary for threads that have terminated in
+	 * order to render possible to restart them.
 	 * 
-	 * @see de.sub.goobi.helper.tasks.EmptyTask#clone()
+	 * @return a not-yet-executed replacement of this thread
+	 * @see de.sub.goobi.helper.tasks.EmptyTask#replace()
 	 */
 	@Override
-	public ExportNewspaperBatchTask clone() {
+	public ExportNewspaperBatchTask replace() {
 		return new ExportNewspaperBatchTask(this);
 	}
 }

--- a/Goobi/src/de/sub/goobi/helper/tasks/LongRunningTask.java
+++ b/Goobi/src/de/sub/goobi/helper/tasks/LongRunningTask.java
@@ -93,14 +93,15 @@ public abstract class LongRunningTask extends EmptyTask implements INameableTask
 	}
 
 	/**
-	 * The function clone() creates a new instance of this object. This is
-	 * necessary for Threads that have terminated in order to render to run them
-	 * again possible.
+	 * Calls the clone constructor to create a not yet executed instance of this
+	 * thread object. This is necessary for threads that have terminated in
+	 * order to render possible to restart them.
 	 * 
-	 * @see de.sub.goobi.helper.tasks.EmptyTask#clone()
+	 * @return a not-yet-executed replacement of this thread
+	 * @see de.sub.goobi.helper.tasks.EmptyTask#replace()
 	 */
 	@Override
-	public abstract EmptyTask clone();
+	public abstract EmptyTask replace();
 
 	/**
 	 * The method stopped() had been used to record that the thread has stopped.

--- a/Goobi/src/de/sub/goobi/helper/tasks/ProcessSwapInTask.java
+++ b/Goobi/src/de/sub/goobi/helper/tasks/ProcessSwapInTask.java
@@ -96,7 +96,7 @@ public class ProcessSwapInTask extends LongRunningTask {
 			setStatusProgress(-1);
 			return;
 		}
-		if (swapPath == null || swapPath.length() == 0) {
+		if ((swapPath == null) || (swapPath.length() == 0)) {
 			setStatusMessage("no swappingPath defined");
 			setStatusProgress(-1);
 			return;
@@ -230,14 +230,15 @@ public class ProcessSwapInTask extends LongRunningTask {
 	}
 
 	/**
-	 * The method clone does call the copy constructor to create a copy of that
-	 * object. This is necessary for Threads that have terminated in order to
-	 * render to run them again possible.
+	 * Calls the clone constructor to create a not yet executed instance of this
+	 * thread object. This is necessary for threads that have terminated in
+	 * order to render possible to restart them.
 	 * 
-	 * @see java.lang.Thread#clone()
+	 * @return a not-yet-executed replacement of this thread
+	 * @see de.sub.goobi.helper.tasks.EmptyTask#replace()
 	 */
 	@Override
-	public ProcessSwapInTask clone() {
+	public ProcessSwapInTask replace() {
 		return new ProcessSwapInTask(this);
 	}
 

--- a/Goobi/src/de/sub/goobi/helper/tasks/ProcessSwapOutTask.java
+++ b/Goobi/src/de/sub/goobi/helper/tasks/ProcessSwapOutTask.java
@@ -97,7 +97,7 @@ public void run() {
          setStatusProgress(-1);
          return;
       }
-      if (swapPath == null || swapPath.length() == 0) {
+      if ((swapPath == null) || (swapPath.length() == 0)) {
          setStatusMessage("no swappingPath defined");
          setStatusProgress(-1);
          return;
@@ -196,14 +196,15 @@ public void run() {
    }
 
 	/**
-	 * The method clone does call the copy constructor to create a copy of that
-	 * object. This is necessary for Threads that have terminated in order to
-	 * render to run them again possible.
+	 * Calls the clone constructor to create a not yet executed instance of this
+	 * thread object. This is necessary for threads that have terminated in
+	 * order to render possible to restart them.
 	 * 
-	 * @see java.lang.Thread#clone()
+	 * @return a not-yet-executed replacement of this thread
+	 * @see de.sub.goobi.helper.tasks.EmptyTask#replace()
 	 */
 	@Override
-	public ProcessSwapOutTask clone() {
+	public ProcessSwapOutTask replace() {
 		return new ProcessSwapOutTask(this);
 	}
 

--- a/Goobi/src/de/sub/goobi/helper/tasks/TaskSitter.java
+++ b/Goobi/src/de/sub/goobi/helper/tasks/TaskSitter.java
@@ -183,7 +183,7 @@ public class TaskSitter implements Runnable, ServletContextListener {
 						}
 						break;
 					case PREPARE_FOR_RESTART:
-						EmptyTask replacement = task.clone();
+						EmptyTask replacement = task.replace();
 						if (replacement != null) {
 							position.set(replacement);
 							launchableThreads.addLast(replacement);


### PR DESCRIPTION
The function is a misnomer. Theads are like matchsticks for one-time use only and cannot be cloned. A burnt down thread needs to be replaced, this is what the implementation already does, so the function was renamed to make clear its behaviour differs from the contract of java.lang.Object#clone().