### PR TITLE
README: Fix instructions for configuration of distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,5 @@ Most probably, you will have to adjust these four files:
 * contentServerConfig.xml
 * hibernate.cfg.xml
 * log4j.properties
-* propertyTemplates.xml
 
 Setting up a Goobi instance can be quite tricky. For more help on how to configure Goobi, please check the web sites above or ask questions on the mailing lists.


### PR DESCRIPTION
File propertyTemplates.xml was removed in 2012 (see commit
aa705c75236b95e52021a3073245d84d9df1b730), so remove it from
the documentation now, too.

Signed-off-by: Stefan Weil <sw@weilnetz.de>

The documentation talks about "these four files" - now there are four files...