### PR TITLE
Add missing licence header

### DIFF
--- a/Goobi/src/de/sub/goobi/metadaten/FileManipulation.java
+++ b/Goobi/src/de/sub/goobi/metadaten/FileManipulation.java
@@ -1,3 +1,26 @@
+/***************************************************************
+ * Copyright notice
+ *
+ * (c) 2013 Robert Sehr <robert.sehr@intranda.com>
+ *
+ * All rights reserved
+ *
+ * This file is part of the Goobi project. The Goobi project is free software;
+ * you can redistribute it and/or modify it under the terms of the GNU General
+ * Public License as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * The GNU General Public License can be found at
+ * http://www.gnu.org/copyleft/gpl.html.
+ *
+ * This script is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * This copyright notice MUST APPEAR in all copies of this file!
+ ***************************************************************/
+
 package de.sub.goobi.metadaten;
 
 import java.io.ByteArrayInputStream;

--- a/Goobi/src/de/sub/goobi/metadaten/Metadatum.java
+++ b/Goobi/src/de/sub/goobi/metadaten/Metadatum.java
@@ -1,3 +1,24 @@
+/*
+ * This file is part of the Goobi Application - a Workflow tool for the support of
+ * mass digitization.
+ *
+ * Visit the websites for more information.
+ *     - http://gdz.sub.uni-goettingen.de
+ *     - http://www.goobi.org
+ *     - http://launchpad.net/goobi-production
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details. You
+ * should have received a copy of the GNU General Public License along with this
+ * program; if not, write to the Free Software Foundation, Inc., 59 Temple Place,
+ * Suite 330, Boston, MA 02111-1307 USA
+ */
 package de.sub.goobi.metadaten;
 
 import java.util.ArrayList;

--- a/Goobi/src/de/sub/goobi/metadaten/Metadatum.java
+++ b/Goobi/src/de/sub/goobi/metadaten/Metadatum.java
@@ -16,8 +16,7 @@
  * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
  * PARTICULAR PURPOSE. See the GNU General Public License for more details. You
  * should have received a copy of the GNU General Public License along with this
- * program; if not, write to the Free Software Foundation, Inc., 59 Temple Place,
- * Suite 330, Boston, MA 02111-1307 USA
+ * program. If not, see <http://www.gnu.org/licenses/>.
  */
 package de.sub.goobi.metadaten;
 

--- a/Goobi/src/de/sub/goobi/metadaten/Metadatum.java
+++ b/Goobi/src/de/sub/goobi/metadaten/Metadatum.java
@@ -5,7 +5,7 @@
  * Visit the websites for more information.
  *     - http://gdz.sub.uni-goettingen.de
  *     - http://www.goobi.org
- *     - http://launchpad.net/goobi-production
+ *     - https://github.com/goobi/goobi-production
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software


### PR DESCRIPTION
Add license header to two files. Taking over from old 1.8.x branch and from intranda fork.

@claussni and @stweil : can you please look over this?