### PR TITLE
Merge: Fix wrong package declaration in tests

### DIFF
--- a/Goobi/test/src/de/sub/goobi/helper/encryption/MD4Test.java
+++ b/Goobi/test/src/de/sub/goobi/helper/encryption/MD4Test.java
@@ -36,7 +36,7 @@
  * your version.
  */
 
-package src.de.sub.goobi.helper.encryption;
+package de.sub.goobi.helper.encryption;
 
 import static org.junit.Assert.assertTrue;
 

--- a/Goobi/test/src/de/sub/goobi/helper/encryption/MD5Test.java
+++ b/Goobi/test/src/de/sub/goobi/helper/encryption/MD5Test.java
@@ -36,7 +36,7 @@
  * your version.
  */
 
-package src.de.sub.goobi.helper.encryption;
+package de.sub.goobi.helper.encryption;
 
 import static org.junit.Assert.assertTrue;
 


### PR DESCRIPTION
Obviously the source folder name has become part of the package declaration by accident. This causes compile errors.