### PR TITLE
Merge: Calendar editor crashes if blocks in XML file overlap (#362)

### DIFF
--- a/Goobi/src/de/sub/goobi/forms/CalendarForm.java
+++ b/Goobi/src/de/sub/goobi/forms/CalendarForm.java
@@ -1346,6 +1346,10 @@ public class CalendarForm {
 			Helper.setFehlerMeldung("calendar.upload.error", "error.IOException");
 			logger.error(e.getMessage(), e);
 			neglectEmptyBlock();
+		} catch (IllegalArgumentException e) {
+			Helper.setFehlerMeldung("calendar.upload.overlappingDateRanges", e.getMessage());
+			logger.error(e.getMessage(), e);
+			neglectEmptyBlock();
 		} catch (NoSuchElementException e) {
 			Helper.setFehlerMeldung("calendar.upload.error", "calendar.upload.missingMandatoryElement");
 			logger.error(e.getMessage(), e);

--- a/Goobi/src/messages/messages_de.properties
+++ b/Goobi/src/messages/messages_de.properties
@@ -324,6 +324,7 @@ calendar.upload=Importieren
 calendar.upload.error=Fehler beim Laden der Datei\:
 calendar.upload.isEmpty=Es wurde keine Datei \u00FCbertragen.
 calendar.upload.missingMandatoryElement=Ein erforderliches XML-Element konnte nicht gefunden werden.
+calendar.upload.overlappingDateRanges=Der Erscheinungsverlauf konnte nicht importiert werden, da sich Datumsbereiche von Bl\u00F6cken \u00FCberlappen\:
 calendar.upload.submit=Hochladen
 calculateStatistics=Statistik berechnen
 category=Kategorie

--- a/Goobi/src/messages/messages_en.properties
+++ b/Goobi/src/messages/messages_en.properties
@@ -328,6 +328,7 @@ calendar.upload=Import
 calendar.upload.error=Error while loading the file\:
 calendar.upload.isEmpty=No file was transferred.
 calendar.upload.missingMandatoryElement=A mandatory XML element could not be found.
+calendar.upload.overlappingDateRanges=Due to overlapping date ranges of blocks, the course of appearance could not be imported\:
 calendar.upload.submit=Submit file
 catalogue_used=Catalogue used\:
 category=Category

--- a/Goobi/src/org/goobi/production/model/bibliography/course/Block.java
+++ b/Goobi/src/org/goobi/production/model/bibliography/course/Block.java
@@ -343,7 +343,7 @@ public class Block {
 	 * @throws IllegalArgumentException
 	 *             if the date would overlap with another block
 	 */
-	public void setFirstAppearance(LocalDate firstAppearance) throws IllegalArgumentException {
+	public void setFirstAppearance(LocalDate firstAppearance) {
 		prohibitOverlaps(firstAppearance, lastAppearance != null ? lastAppearance : firstAppearance);
 		try {
 			if (!this.firstAppearance.equals(firstAppearance)) {
@@ -430,12 +430,12 @@ public class Block {
 	 * @throws IllegalArgumentException
 	 *             if the check fails
 	 */
-	private void prohibitOverlaps(LocalDate from, LocalDate until) throws IllegalArgumentException {
+	private void prohibitOverlaps(LocalDate from, LocalDate until) {
 		for (Block block : course) {
 			if (!block.equals(this)
 					&& (block.getFirstAppearance().isBefore(until) && !block.getLastAppearance().isBefore(from) || (block
 							.getLastAppearance().isAfter(from) && !block.getFirstAppearance().isAfter(until)))) {
-				throw new IllegalArgumentException();
+				throw new IllegalArgumentException('(' + block.variant + ") " + block.firstAppearance + " - " + block.lastAppearance);
 			}
 		}
 	}

--- a/Goobi/src/org/goobi/production/model/bibliography/course/Course.java
+++ b/Goobi/src/org/goobi/production/model/bibliography/course/Course.java
@@ -200,8 +200,8 @@ public class Course extends ArrayList<Block> {
 	 *            XML document data structure
 	 * @throws NoSuchElementException
 	 *             if ELEMENT_COURSE or ELEMENT_PROCESSES cannot be found
-     * @throws IllegalArgumentException
-     *             if the dates of two blocks do overlap
+	 * @throws IllegalArgumentException
+	 *             if the dates of two blocks do overlap
 	 */
 	public Course(Document xml) throws NoSuchElementException {
 		super();
@@ -276,8 +276,9 @@ public class Course extends ArrayList<Block> {
 	 * @param date
 	 *            date to add
 	 * @return an IndividualIssue representing the added issue
-     * @throws IllegalArgumentException
-     *             if the date would cause the block to overlap with another block
+	 * @throws IllegalArgumentException
+	 *             if the date would cause the block to overlap with another
+	 *             block
 	 */
 	private IndividualIssue addAddition(String variant, String issueHeading, LocalDate date) {
 		Block block = get(variant);

--- a/Goobi/src/org/goobi/production/model/bibliography/course/Course.java
+++ b/Goobi/src/org/goobi/production/model/bibliography/course/Course.java
@@ -200,6 +200,8 @@ public class Course extends ArrayList<Block> {
 	 *            XML document data structure
 	 * @throws NoSuchElementException
 	 *             if ELEMENT_COURSE or ELEMENT_PROCESSES cannot be found
+     * @throws IllegalArgumentException
+     *             if the dates of two blocks do overlap
 	 */
 	public Course(Document xml) throws NoSuchElementException {
 		super();
@@ -274,13 +276,19 @@ public class Course extends ArrayList<Block> {
 	 * @param date
 	 *            date to add
 	 * @return an IndividualIssue representing the added issue
+     * @throws IllegalArgumentException
+     *             if the date would cause the block to overlap with another block
 	 */
 	private IndividualIssue addAddition(String variant, String issueHeading, LocalDate date) {
 		Block block = get(variant);
 		if (block == null) {
 			block = new Block(this, variant);
-			block.setFirstAppearance(date);
-			block.setLastAppearance(date);
+			try {
+				block.setFirstAppearance(date);
+				block.setLastAppearance(date);
+			} catch (IllegalArgumentException e) {
+				throw new IllegalArgumentException(e.getMessage() + ", (" + variant + ") " + date, e);
+			}
 			add(block);
 		} else {
 			if (block.getFirstAppearance().isAfter(date)) {


### PR DESCRIPTION
Fix bug #362 
Shows an error message, as for the example: *Due to overlapping date ranges of blocks, the course of appearance could not be imported: (A block) 1975-01-02 - 1975-01-04, (Another block) 1975-01-03*