### PR TITLE
Clean up code (Eclipse)

### DIFF
--- a/Goobi/src/de/sub/goobi/forms/ModuleServerForm.java
+++ b/Goobi/src/de/sub/goobi/forms/ModuleServerForm.java
@@ -113,6 +113,7 @@ public class ModuleServerForm {
 			int period = 1000;
 			messageTimer = new Timer();
 			messageTimer.scheduleAtFixedRate(new TimerTask() {
+				@Override
 				public void run() {
 					ModuleServerForm.check_new_messages(modulmanager);
 				}

--- a/Goobi/src/de/sub/goobi/helper/servletfilter/SessionCounterFilter.java
+++ b/Goobi/src/de/sub/goobi/helper/servletfilter/SessionCounterFilter.java
@@ -51,6 +51,7 @@ import de.sub.goobi.forms.SessionForm;
 public class SessionCounterFilter implements Filter {
    ServletContext servletContext;
 
+   @Override
    public void init(FilterConfig filterConfig) throws ServletException {
       servletContext = filterConfig.getServletContext();
    }
@@ -59,6 +60,7 @@ public class SessionCounterFilter implements Filter {
 
    /**
     */
+   @Override
    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
          throws IOException, ServletException {
 
@@ -118,6 +120,7 @@ public class SessionCounterFilter implements Filter {
 
    /**
     */
+   @Override
    public void destroy() {
       // Nothing necessary
    }

--- a/Goobi/src/de/sub/goobi/metadaten/MetadatumImpl.java
+++ b/Goobi/src/de/sub/goobi/metadaten/MetadatumImpl.java
@@ -73,6 +73,7 @@ public class MetadatumImpl implements Metadatum {
 		}
 	}
 
+	@Override
 	public ArrayList<Item> getWert() {
 		String value = this.md.getValue();
 		if (value != null) {
@@ -87,10 +88,12 @@ public class MetadatumImpl implements Metadatum {
 		return this.myValues.get(Modes.getBindState().getTitle()).getItemList();
 	}
 
+	@Override
 	public void setWert(String inWert) {
 		this.md.setValue(inWert.trim());
 	}
 
+	@Override
 	public String getTyp() {
 		String label = this.md.getType().getLanguage((String) Helper.getManagedBeanValue("#{LoginForm.myBenutzer.metadatenSprache}"));
 		if (label == null) {
@@ -99,6 +102,7 @@ public class MetadatumImpl implements Metadatum {
 		return label;
 	}
 
+	@Override
 	public void setTyp(String inTyp) {
 		MetadataType mdt = this.myPrefs.getMetadataTypeByName(inTyp);
 		this.md.setType(mdt);
@@ -109,18 +113,22 @@ public class MetadatumImpl implements Metadatum {
 	 * ##################################################### ####################################################
 	 */
 
+	@Override
 	public int getIdentifier() {
 		return this.identifier;
 	}
 
+	@Override
 	public void setIdentifier(int identifier) {
 		this.identifier = identifier;
 	}
 
+	@Override
 	public Metadata getMd() {
 		return this.md;
 	}
 
+	@Override
 	public void setMd(Metadata md) {
 		this.md = md;
 	}
@@ -131,10 +139,12 @@ public class MetadatumImpl implements Metadatum {
 	 * 
 	 *****************************************************/
 
+	@Override
 	public String getOutputType() {
 		return this.myValues.get(Modes.getBindState().getTitle()).getDisplayType().getTitle();
 	}
 
+	@Override
 	public List<SelectItem> getItems() {
 		this.items = new ArrayList<SelectItem>();
 		this.selectedItems = new ArrayList<String>();
@@ -147,6 +157,7 @@ public class MetadatumImpl implements Metadatum {
 		return this.items;
 	}
 
+	@Override
 	public void setItems(List<SelectItem> items) {
 		for (Item i : this.myValues.get(Modes.getBindState().getTitle()).getItemList()) {
 			i.setIsSelected(false);
@@ -163,6 +174,7 @@ public class MetadatumImpl implements Metadatum {
 		setWert(val);
 	}
 
+	@Override
 	public List<String> getSelectedItems() {
 		this.selectedItems = new ArrayList<String>();
 		String values = this.md.getValue();
@@ -199,6 +211,7 @@ public class MetadatumImpl implements Metadatum {
 		return this.selectedItems;
 	}
 
+	@Override
 	public void setSelectedItems(List<String> selectedItems) {
 
 		String val = "";
@@ -213,6 +226,7 @@ public class MetadatumImpl implements Metadatum {
 		setWert(val);
 	}
 
+	@Override
 	public String getSelectedItem() {
 		String value = this.md.getValue();
 		if (value!=null && value.length() != 0) {
@@ -233,6 +247,7 @@ public class MetadatumImpl implements Metadatum {
 		return "";
 	}
 
+	@Override
 	public void setSelectedItem(String selectedItem) {
 
 		for (Item i : this.myValues.get(Modes.getBindState().getTitle()).getItemList()) {
@@ -242,10 +257,12 @@ public class MetadatumImpl implements Metadatum {
 		}
 	}
 
+	@Override
 	public void setValue(String value) {
 		setWert(value);
 	}
 
+	@Override
 	public String getValue() {
 		return this.md.getValue();
 	}

--- a/Goobi/src/de/sub/goobi/modul/ExtendedProzessImpl.java
+++ b/Goobi/src/de/sub/goobi/modul/ExtendedProzessImpl.java
@@ -58,6 +58,7 @@ public class ExtendedProzessImpl extends ProcessImpl {
     * @return ProzessID
     * @throws GoobiException: 1, 2, 4, 5, 6, 254, 1400
     * ================================================================*/
+   @Override
    public String get(String sessionID) throws GoobiException {
       super.get(sessionID);
       return String.valueOf(ModuleServerForm.getProcessFromShortSession(sessionID).getId().intValue());
@@ -69,6 +70,7 @@ public class ExtendedProzessImpl extends ProcessImpl {
     * @return Pfad zur XML Datei (String)
     * @throws GoobiException: 1, 2, 4, 5, 6, 254, 1400, 1401
     * ================================================================*/
+   @Override
    public String getFullTextFile(String sessionId) throws GoobiException {
       super.getFullTextFile(sessionId);
       try {
@@ -90,6 +92,7 @@ public class ExtendedProzessImpl extends ProcessImpl {
     * @return Arbeitsverzeichnis (String)
     * @throws GoobiException: 1, 2, 4, 5, 6, 254, 1400, 1401
     * ================================================================*/
+   @Override
    public String getImageDir(String sessionId) throws GoobiException {
       super.getImageDir(sessionId);
       try {
@@ -111,6 +114,7 @@ public class ExtendedProzessImpl extends ProcessImpl {
     * @return Pfad zur XML Datei (String)
     * @throws GoobiException: 1, 2, 4, 5, 6, 254, 1400, 1401
     * ================================================================*/
+   @Override
    public String getMetadataFile(String sessionId) throws GoobiException {
       super.getMetadataFile(sessionId);
       try {
@@ -133,6 +137,7 @@ public class ExtendedProzessImpl extends ProcessImpl {
     * @return Parameter Struktur
     * @throws GoobiException: 1, 2, 4, 5, 6, 254
     * ================================================================*/
+   @Override
    public HashMap<String, String> getParams(String sessionId) throws GoobiException {
       super.getParams(sessionId);
       HashMap<String, String> myMap = new HashMap<String, String>();
@@ -159,6 +164,7 @@ public class ExtendedProzessImpl extends ProcessImpl {
     * @return Projekttitel (String)
     * @throws GoobiException: 1, 2, 4, 5, 6, 254, 1400
     * ================================================================*/
+   @Override
    public String getProject(String sessionId) throws GoobiException {
       super.getProject(sessionId);
       return ModuleServerForm.getProcessFromShortSession(sessionId).getProjekt().getTitel();
@@ -171,6 +177,7 @@ public class ExtendedProzessImpl extends ProcessImpl {
     * @return Prozesstitel (String)
     * @throws GoobiException: 1, 2, 4, 5, 6, 254, 1400
     * ================================================================*/
+   @Override
    public String getTitle(String sessionId) throws GoobiException {
       super.getTitle(sessionId);
       return ModuleServerForm.getProcessFromShortSession(sessionId).getTitel();

--- a/Goobi/src/de/sub/goobi/modul/ModulListener.java
+++ b/Goobi/src/de/sub/goobi/modul/ModulListener.java
@@ -38,12 +38,14 @@ import de.sub.goobi.forms.ModuleServerForm;
 public class ModulListener implements ServletContextListener {
    private static final Logger myLogger = Logger.getLogger(ModulListener.class);
 
+   @Override
    public void contextInitialized(ServletContextEvent event) {
       myLogger.debug("Starte Modularisierung-Server", null);
       new ModuleServerForm().startAllModules();
       myLogger.debug("Gestartet: Modularisierung-Server", null);
    }
 
+   @Override
    public void contextDestroyed(ServletContextEvent event) {
       myLogger.debug("Stoppe Modularisierung-Server", null);
       new ModuleServerForm().stopAllModules();

--- a/Goobi/src/edu/sysu/virgoftp/ftp/encrypt/MD4.java
+++ b/Goobi/src/edu/sysu/virgoftp/ftp/encrypt/MD4.java
@@ -52,11 +52,11 @@ private static int ROUND1(int a,int b,int c,int d,int k,int s) {
 }
 
 private static int ROUND2(int a,int b,int c,int d,int k,int s) {
-    return lshift(a + G(b, c, d) + X[k] + (int)0x5A827999, s);
+    return lshift(a + G(b, c, d) + X[k] + 0x5A827999, s);
 }
 
 private static int ROUND3(int a,int b,int c,int d,int k,int s) {
-    return( lshift(a + H(b,c,d) + X[k] + (int)0x6ED9EBA1,s) );
+    return( lshift(a + H(b,c,d) + X[k] + 0x6ED9EBA1,s) );
 }
 
 
@@ -110,7 +110,7 @@ public static void copy64(int M[], byte in[], int offset)
 		M[i] = ((in[offset + i * 4 + 3] << 24) & 0xFF000000)
 		       | ((in[offset + i * 4 + 2] << 16) & 0xFF0000)
 		       | ((in[offset + i * 4 + 1] << 8) & 0xFF00)
-		       | (((int)in[offset + i * 4 + 0]) & 0xFF);
+		       | ((in[offset + i * 4 + 0]) & 0xFF);
 	}
 }
 

--- a/Goobi/src/org/goobi/io/FileListFilter.java
+++ b/Goobi/src/org/goobi/io/FileListFilter.java
@@ -42,6 +42,7 @@ public class FileListFilter implements FilenameFilter {
 		this.name = name;
 	}
 
+	@Override
 	public boolean accept(File directory, String filename) {
 		return filename.matches(name);
 	}

--- a/Goobi/src/org/goobi/production/GoobiVersionListener.java
+++ b/Goobi/src/org/goobi/production/GoobiVersionListener.java
@@ -47,6 +47,7 @@ public class GoobiVersionListener implements ServletContextListener, HttpSession
 	public GoobiVersionListener() {
 	}
 
+	@Override
 	public void contextInitialized(ServletContextEvent sce) {
 
 		// Retrieve Manifest file as Stream
@@ -63,21 +64,27 @@ public class GoobiVersionListener implements ServletContextListener, HttpSession
 		} 		
 	}
 
+	@Override
 	public void contextDestroyed(ServletContextEvent sce) {
 	}
 
+	@Override
 	public void sessionCreated(HttpSessionEvent se) {
 	}
 
+	@Override
 	public void sessionDestroyed(HttpSessionEvent se) {
 	}
 
+	@Override
 	public void attributeAdded(HttpSessionBindingEvent sbe) {
 	}
 
+	@Override
 	public void attributeRemoved(HttpSessionBindingEvent sbe) {
 	}
 
+	@Override
 	public void attributeReplaced(HttpSessionBindingEvent sbe) {
 	}
 

--- a/Goobi/src/org/goobi/production/ImageIOInitializer.java
+++ b/Goobi/src/org/goobi/production/ImageIOInitializer.java
@@ -50,9 +50,11 @@ public class ImageIOInitializer implements ServletContextListener {
 		ImageIO.scanForPlugins();
 	}
 
+	@Override
 	public void contextInitialized(ServletContextEvent sce) {
 	}
 
+	@Override
 	public void contextDestroyed(ServletContextEvent sce) {
 	}
 

--- a/Goobi/src/org/goobi/production/chart/ProjectTask.java
+++ b/Goobi/src/org/goobi/production/chart/ProjectTask.java
@@ -40,22 +40,27 @@ public class ProjectTask implements IProjectTask {
 		checkSizes();
 	}
 
+	@Override
 	public String getTitle() {
 		return taskTitle;
 	}
 
+	@Override
 	public Integer getStepsCompleted() {
 		return taskStepsCompleted;
 	}
 
+	@Override
 	public Integer getStepsMax() {
 		return taskStepsMax;
 	}
 
+	@Override
 	public void setStepsCompleted(Integer stepsCompleted) {
 		taskStepsCompleted = stepsCompleted;
 	}
 
+	@Override
 	public void setStepsMax(Integer stepsMax) {
 		taskStepsMax = stepsMax;
 	}

--- a/Goobi/src/org/goobi/production/chart/WorkflowProjectTaskList.java
+++ b/Goobi/src/org/goobi/production/chart/WorkflowProjectTaskList.java
@@ -47,6 +47,7 @@ import de.sub.goobi.beans.Projekt;
 
 public class WorkflowProjectTaskList implements IProvideProjectTaskList {
 
+	@Override
 	public List<IProjectTask> calculateProjectTasks(Projekt inProject, Boolean countImages, Integer inMax) {
 		List<IProjectTask> myTaskList = new ArrayList<IProjectTask>();
 		calculate(inProject, myTaskList, countImages, inMax);

--- a/Goobi/src/org/goobi/production/flow/jobs/AbstractGoobiJob.java
+++ b/Goobi/src/org/goobi/production/flow/jobs/AbstractGoobiJob.java
@@ -47,6 +47,7 @@ public abstract class AbstractGoobiJob implements Job, IGoobiJob {
 	/* (non-Javadoc)
 	 * @see org.goobi.production.flow.jobs.IGoobiJob#execute(org.quartz.JobExecutionContext)
 	 */
+	@Override
 	public void execute(JobExecutionContext context) throws JobExecutionException {
 		if (getIsRunning() == false) {
 			logger.trace("Start scheduled Job: " + getJobName());
@@ -63,6 +64,7 @@ public abstract class AbstractGoobiJob implements Job, IGoobiJob {
 	/* (non-Javadoc)
 	 * @see org.goobi.production.flow.jobs.IGoobiJob#setIsRunning(java.lang.Boolean)
 	 */
+	@Override
 	public void setIsRunning(Boolean inisRunning) {
 		isRunning = inisRunning;
 	}
@@ -70,6 +72,7 @@ public abstract class AbstractGoobiJob implements Job, IGoobiJob {
 	/* (non-Javadoc)
 	 * @see org.goobi.production.flow.jobs.IGoobiJob#getIsRunning()
 	 */
+	@Override
 	public Boolean getIsRunning() {
 		return isRunning;
 	}
@@ -77,6 +80,7 @@ public abstract class AbstractGoobiJob implements Job, IGoobiJob {
 	/* (non-Javadoc)
 	 * @see org.goobi.production.flow.jobs.IGoobiJob#getJobName()
 	 */
+	@Override
 	public String getJobName() {
 		return "";
 	}
@@ -84,6 +88,7 @@ public abstract class AbstractGoobiJob implements Job, IGoobiJob {
 	/* (non-Javadoc)
 	 * @see org.goobi.production.flow.jobs.IGoobiJob#execute()
 	 */
+	@Override
 	public void execute() {
 	}
 

--- a/Goobi/src/org/goobi/production/flow/statistics/hibernate/SQLProduction.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/hibernate/SQLProduction.java
@@ -52,6 +52,7 @@ class SQLProduction extends SQLGenerator {
 	 * 
 	 * @return String
 	 **********************************************************************/
+	@Override
 	public String getSQL() {
 
 		String subQuery = "";

--- a/Goobi/src/org/goobi/production/flow/statistics/hibernate/SQLStorage.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/hibernate/SQLStorage.java
@@ -54,6 +54,7 @@ public class SQLStorage extends SQLGenerator {
 	 * (non-Javadoc)
 	 * @see org.goobi.production.flow.statistics.hibernate.SQLGenerator#getSQL()
 	 */
+	@Override
 	public String getSQL() {
 
 		String subQuery = "";

--- a/Goobi/src/org/goobi/production/flow/statistics/hibernate/StatQuestProjectAssociations.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/hibernate/StatQuestProjectAssociations.java
@@ -58,6 +58,7 @@ public class StatQuestProjectAssociations implements IStatisticalQuestion {
 	 * (non-Javadoc)
 	 * @see org.goobi.production.flow.statistics.IStatisticalQuestion#getDataTables(org.goobi.production.flow.statistics.IDataSource)
 	 */
+	@Override
 	public List<DataTable> getDataTables(IDataSource dataSource) {
 
 		IEvaluableFilter originalFilter;
@@ -111,6 +112,7 @@ public class StatQuestProjectAssociations implements IStatisticalQuestion {
 	 * (non-Javadoc)
 	 * @see org.goobi.production.flow.statistics.IStatisticalQuestion#isRendererInverted(de.intranda.commons.chart.renderer.IRenderer)
 	 */
+	@Override
 	public Boolean isRendererInverted(IRenderer inRenderer) {
 		return inRenderer instanceof HtmlTableRenderer;
 	}
@@ -119,6 +121,7 @@ public class StatQuestProjectAssociations implements IStatisticalQuestion {
 	 * (non-Javadoc)
 	 * @see org.goobi.production.flow.statistics.IStatisticalQuestion#setCalculationUnit(org.goobi.production.flow.statistics.enums.CalculationUnit)
 	 */
+	@Override
 	public void setCalculationUnit(CalculationUnit cu) {
 	}
 
@@ -126,6 +129,7 @@ public class StatQuestProjectAssociations implements IStatisticalQuestion {
 	 * (non-Javadoc)
 	 * @see org.goobi.production.flow.statistics.IStatisticalQuestion#setTimeUnit(org.goobi.production.flow.statistics.enums.TimeUnit)
 	 */
+	@Override
 	public void setTimeUnit(TimeUnit timeUnit) {
 	}
 
@@ -133,6 +137,7 @@ public class StatQuestProjectAssociations implements IStatisticalQuestion {
 	 * (non-Javadoc)
 	 * @see org.goobi.production.flow.statistics.IStatisticalQuestion#getNumberFormatPattern()
 	 */
+	@Override
 	public String getNumberFormatPattern() {
 		return "#";
 	}

--- a/Goobi/src/org/goobi/production/flow/statistics/hibernate/StatQuestUsergroups.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/hibernate/StatQuestUsergroups.java
@@ -58,6 +58,7 @@ public class StatQuestUsergroups implements IStatisticalQuestion {
 	 * (non-Javadoc)
 	 * @see org.goobi.production.flow.statistics.IStatisticalQuestion#getDataTables(org.goobi.production.flow.statistics.IDataSource)
 	 */
+	@Override
 	public List<DataTable> getDataTables(IDataSource dataSource) {
 
 		IEvaluableFilter originalFilter;
@@ -100,6 +101,7 @@ public class StatQuestUsergroups implements IStatisticalQuestion {
 	 * (non-Javadoc)
 	 * @see org.goobi.production.flow.statistics.IStatisticalQuestion#isRendererInverted(de.intranda.commons.chart.renderer.IRenderer)
 	 */
+	@Override
 	public Boolean isRendererInverted(IRenderer inRenderer) {
 		return inRenderer instanceof HtmlTableRenderer;
 	}
@@ -108,6 +110,7 @@ public class StatQuestUsergroups implements IStatisticalQuestion {
 	 * (non-Javadoc)
 	 * @see org.goobi.production.flow.statistics.IStatisticalQuestion#setCalculationUnit(org.goobi.production.flow.statistics.enums.CalculationUnit)
 	 */
+	@Override
 	public void setCalculationUnit(CalculationUnit cu) {
 	}
 
@@ -115,6 +118,7 @@ public class StatQuestUsergroups implements IStatisticalQuestion {
 	 * (non-Javadoc)
 	 * @see org.goobi.production.flow.statistics.IStatisticalQuestion#setTimeUnit(org.goobi.production.flow.statistics.enums.TimeUnit)
 	 */
+	@Override
 	public void setTimeUnit(TimeUnit timeUnit) {
 	}
 
@@ -122,6 +126,7 @@ public class StatQuestUsergroups implements IStatisticalQuestion {
 	 * (non-Javadoc)
 	 * @see org.goobi.production.flow.statistics.IStatisticalQuestion#getNumberFormatPattern()
 	 */
+	@Override
 	public String getNumberFormatPattern() {
 		return "#";
 	}

--- a/Goobi/src/org/goobi/production/flow/statistics/hibernate/StatQuestVolumeStatus.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/hibernate/StatQuestVolumeStatus.java
@@ -57,6 +57,7 @@ public class StatQuestVolumeStatus implements IStatisticalQuestion {
 	 * (non-Javadoc)
 	 * @see org.goobi.production.flow.statistics.IStatisticalQuestion#getDataTables(org.goobi.production.flow.statistics.IDataSource)
 	 */
+	@Override
 	public List<DataTable> getDataTables(IDataSource dataSource) {
 
 		IEvaluableFilter originalFilter;
@@ -98,6 +99,7 @@ public class StatQuestVolumeStatus implements IStatisticalQuestion {
 	 * (non-Javadoc)
 	 * @see org.goobi.production.flow.statistics.IStatisticalQuestion#isRendererInverted(de.intranda.commons.chart.renderer.IRenderer)
 	 */
+	@Override
 	public Boolean isRendererInverted(IRenderer inRenderer) {
 		return inRenderer instanceof HtmlTableRenderer;
 	}
@@ -106,6 +108,7 @@ public class StatQuestVolumeStatus implements IStatisticalQuestion {
 	 * (non-Javadoc)
 	 * @see org.goobi.production.flow.statistics.IStatisticalQuestion#setCalculationUnit(org.goobi.production.flow.statistics.enums.CalculationUnit)
 	 */
+	@Override
 	public void setCalculationUnit(CalculationUnit cu) {
 	}
 
@@ -113,6 +116,7 @@ public class StatQuestVolumeStatus implements IStatisticalQuestion {
 	 * (non-Javadoc)
 	 * @see org.goobi.production.flow.statistics.IStatisticalQuestion#setTimeUnit(org.goobi.production.flow.statistics.enums.TimeUnit)
 	 */
+	@Override
 	public void setTimeUnit(TimeUnit timeUnit) {
 	}
 
@@ -120,6 +124,7 @@ public class StatQuestVolumeStatus implements IStatisticalQuestion {
 	 * (non-Javadoc)
 	 * @see org.goobi.production.flow.statistics.IStatisticalQuestion#getNumberFormatPattern()
 	 */
+	@Override
 	public String getNumberFormatPattern() {
 		return "#";
 	}

--- a/Goobi/src/org/goobi/production/properties/ImportProperty.java
+++ b/Goobi/src/org/goobi/production/properties/ImportProperty.java
@@ -194,12 +194,14 @@ public class ImportProperty implements IProperty{
 		}
 	}
 
+	@Override
 	public void setDateValue(Date inDate) {
 		SimpleDateFormat format = new SimpleDateFormat("dd.MM.yyyy");
 		value= format.format(inDate);
 	}
 
 	
+	@Override
 	public Date getDateValue() {
 		SimpleDateFormat format = new SimpleDateFormat("dd.MM.yyyy");
 		try {

--- a/Goobi/src/org/goobi/production/properties/ProcessProperty.java
+++ b/Goobi/src/org/goobi/production/properties/ProcessProperty.java
@@ -185,12 +185,14 @@ public class ProcessProperty implements IProperty, Serializable {
 	}
 
 	
+	@Override
 	public void setDateValue(Date inDate) {
 		SimpleDateFormat format = new SimpleDateFormat("dd.MM.yyyy");
 		value= format.format(inDate);
 	}
 
 	
+	@Override
 	public Date getDateValue() {
 		SimpleDateFormat format = new SimpleDateFormat("dd.MM.yyyy");
 		try {

--- a/Goobi/src/org/goobi/webapi/beans/IdentifierPPN.java
+++ b/Goobi/src/org/goobi/webapi/beans/IdentifierPPN.java
@@ -58,6 +58,7 @@ public class IdentifierPPN {
         return result;
     }
 
+    @Override
     public String toString() {
         return ppn;
     }

--- a/Goobi/src/org/goobi/webapi/dao/GoobiProcessDAO.java
+++ b/Goobi/src/org/goobi/webapi/dao/GoobiProcessDAO.java
@@ -107,7 +107,7 @@ public class GoobiProcessDAO {
                     .setResultTransformer(Transformers.aliasToBean(GoobiProcess.class));
 
             @SuppressWarnings(value = "unchecked")
-            List<GoobiProcess> list = (List<GoobiProcess>) criteria.list();
+            List<GoobiProcess> list = criteria.list();
 
             if ((list != null) && (list.size() > 0)) {
                 result.addAll(list);
@@ -144,7 +144,7 @@ public class GoobiProcessDAO {
                     .setResultTransformer(Transformers.aliasToBean(GoobiProcessStep.class));
 
             @SuppressWarnings(value = "unchecked")
-            List<GoobiProcessStep> list = (List<GoobiProcessStep>) criteria.list();
+            List<GoobiProcessStep> list = criteria.list();
 
             if ((list != null) && (!list.isEmpty())) {
                 result.addAll(list);

--- a/Goobi/src/org/goobi/webapi/provider/ParamExceptionMapper.java
+++ b/Goobi/src/org/goobi/webapi/provider/ParamExceptionMapper.java
@@ -37,6 +37,7 @@ import javax.ws.rs.ext.Provider;
 
 @Provider
 public class ParamExceptionMapper implements ExceptionMapper<ParamException> {
+    @Override
     public Response toResponse(ParamException e) {
         return Response.status(Response.Status.BAD_REQUEST)
                 .entity(e.getCause().getMessage())


### PR DESCRIPTION
When running "clean up" in Eclipse, missing annotations and superfluous type casts are two of the issues which get fixed. These patches contain the resulting code.