### PR TITLE
Revert "Fix Coverity CID 44602, CID 44700, CID 44719 (Explicit null dereferen…"

### DIFF
--- a/Goobi/src/org/goobi/production/flow/statistics/hibernate/UserDefinedFilter.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/hibernate/UserDefinedFilter.java
@@ -188,7 +188,7 @@ public class UserDefinedFilter implements IEvaluableFilter, Cloneable {
 		 * part was exported to FilterHelper so that other Filters could access
 		 * it * --------------------------------
 		 */
-		String message = FilterHelper.criteriaBuilder(session, inFilter, crit, null, myParameter, false, null, true);
+		String message = FilterHelper.criteriaBuilder(session, inFilter, crit, null, myParameter, null, null, true);
 		if (message.length() > 0) {
 			myObservable.setMessage(message);
 		}

--- a/Goobi/src/org/goobi/production/flow/statistics/hibernate/UserProcessesFilter.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/hibernate/UserProcessesFilter.java
@@ -62,7 +62,7 @@ public class UserProcessesFilter implements IEvaluableFilter, Cloneable {
 		Session session = Helper.getHibernateSession();
 		PaginatingCriteria crit = new PaginatingCriteria(Prozess.class, session);
 
-		FilterHelper.criteriaBuilder(session, null, crit, false, null, false, null, clearSession);
+		FilterHelper.criteriaBuilder(session, null, crit, false, null, null, null, clearSession);
 		return crit;
 	}
 

--- a/Goobi/src/org/goobi/production/flow/statistics/hibernate/UserTemplatesFilter.java
+++ b/Goobi/src/org/goobi/production/flow/statistics/hibernate/UserTemplatesFilter.java
@@ -64,7 +64,7 @@ public class UserTemplatesFilter implements IEvaluableFilter, Cloneable {
 
 		Session session = Helper.getHibernateSession();
 		PaginatingCriteria crit = new PaginatingCriteria(Prozess.class, session);
-		FilterHelper.criteriaBuilder(session, null, crit, true, null, false, null, clearSession);
+		FilterHelper.criteriaBuilder(session, null, crit, true, null, null, null, clearSession);
 
 		return crit;
 	}


### PR DESCRIPTION
As far as I see it, Coverity has failed here. The `Boolean` object is correcty null-checked and evaluated ([here](https://github.com/goobi/goobi-production/blob/1.11.x/Goobi/src/org/goobi/production/flow/statistics/hibernate/FilterHelper.java#L617-L626)). Changing this to `false` *is* a behavioural change, as it will add a condition for *istTemplate==false*.

Or am I missing something essential here?

Reverts goobi/goobi-production#375