### PR TITLE
Re-add Eclipse entries to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,11 +4,3 @@
 /config-local
 /deploy.properties
 /dist
-
-# Eclipse
-/.project
-/.classpath
-/.settings/
-
-# Eclipse: /Goobi/ deployed as root of web application
-/Goobi/META-INF/

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,10 @@
 /deploy.properties
 /dist
 
-# Eclipse (Goobi deployed as root of web application).
+# Eclipse
+/.project
+/.classpath
+/.settings/
+
+# Eclipse: /Goobi/ deployed as root of web application
 /Goobi/META-INF/

--- a/doc/developer/eclipse.md
+++ b/doc/developer/eclipse.md
@@ -1,0 +1,19 @@
+Developing Goobi Production using Eclipse
+=========================================
+
+How not to commit the Eclipse `.project` files
+------------------------------------------------
+
+ * Go to the file system, find the `.git` folder in your Eclipse Goobi Production project.
+ * Find the `info` subfolder (or create it if missing)
+ * Create a file named `exclude` (no extension).
+ * Put any files and directories you need to exclude there.
+ 
+Example content:
+
+```txt
+/.project
+/.classpath
+/.settings/
+/Goobi/META-INF/
+```


### PR DESCRIPTION
Comment was unclear. The three Eclipse entries should still remain in `.gitignore` file, and *META-INF* should have been added additionally. 