### PR TITLE
Do null check on java.io.File list() results

### DIFF
--- a/Goobi/src/de/sub/goobi/beans/Prozess.java
+++ b/Goobi/src/de/sub/goobi/beans/Prozess.java
@@ -405,7 +405,7 @@ public class Prozess implements Serializable {
 		if (tifOrdner.equals("") && useFallBack) {
 			String suffix = ConfigMain.getParameter("MetsEditorDefaultSuffix", "");
 			if (!suffix.equals("")) {
-				String[] folderList = dir.list();
+				String[] folderList = FilesystemHelper.list(dir);
 				for (String folder : folderList) {
 					if (folder.endsWith(suffix)) {
 						tifOrdner = folder;
@@ -421,7 +421,7 @@ public class Prozess implements Serializable {
 	                File tif = new File(tifOrdner);
 	                String[] files = tif.list();
 	                if (files == null || files.length == 0) {
-	                    String[] folderList = dir.list();
+	                    String[] folderList = FilesystemHelper.list(dir);
 	                    for (String folder : folderList) {
 	                        if (folder.endsWith(suffix) && !folder.startsWith(DIRECTORY_PREFIX)) {
 	                            tifOrdner = folder;
@@ -466,7 +466,7 @@ public class Prozess implements Serializable {
 		if (testMe.list() == null) {
 			return false;
 		}
-		if (testMe.exists() && testMe.list().length > 0) {
+		if (testMe.exists() && FilesystemHelper.list(testMe).length > 0) {
 			return true;
 		} else {
 			return false;
@@ -487,7 +487,7 @@ public class Prozess implements Serializable {
 			};
 
 			String origOrdner = "";
-			String[] verzeichnisse = dir.list(filterVerz);
+			String[] verzeichnisse = FilesystemHelper.list(dir, filterVerz);
 			for (int i = 0; i < verzeichnisse.length; i++) {
 				origOrdner = verzeichnisse[i];
 			}
@@ -495,7 +495,7 @@ public class Prozess implements Serializable {
 			if (origOrdner.equals("") && useFallBack) {
 				String suffix = ConfigMain.getParameter("MetsEditorDefaultSuffix", "");
 				if (!suffix.equals("")) {
-					String[] folderList = dir.list();
+					String[] folderList = FilesystemHelper.list(dir);
 					for (String folder : folderList) {
 						if (folder.endsWith(suffix)) {
 							origOrdner = folder;
@@ -511,7 +511,7 @@ public class Prozess implements Serializable {
 					File tif = new File(origOrdner);
 					String[] files = tif.list();
 					if (files == null || files.length == 0) {
-						String[] folderList = dir.list();
+						String[] folderList = FilesystemHelper.list(dir);
 						for (String folder : folderList) {
 							if (folder.endsWith(suffix)) {
 								origOrdner = folder;
@@ -1049,7 +1049,7 @@ public class Prozess implements Serializable {
 	private void removePrefixFromRelatedMetsAnchorFilesFor(String temporaryMetadataFilename) throws IOException {
 		File temporaryFile = new File(temporaryMetadataFilename);
 		File directoryPath = new File(temporaryFile.getParentFile().getPath());
-		for (File temporaryAnchorFile : directoryPath.listFiles()) {
+		for (File temporaryAnchorFile : FilesystemHelper.listFiles(directoryPath)) {
 			String temporaryAnchorFileName = temporaryAnchorFile.toString();
 			if (temporaryAnchorFile.isFile()
 					&& FilenameUtils.getBaseName(temporaryAnchorFileName).startsWith(TEMPORARY_FILENAME_PREFIX)) {

--- a/Goobi/src/de/sub/goobi/export/dms/AutomaticDmsExportWithoutHibernate.java
+++ b/Goobi/src/de/sub/goobi/export/dms/AutomaticDmsExportWithoutHibernate.java
@@ -320,13 +320,13 @@ public class AutomaticDmsExportWithoutHibernate extends ExportMetsWithoutHiberna
 
 		// download sources
 		File sources = new File(fi.getSourceDirectory());
-		if (sources.exists() && sources.list().length > 0) {
+		if (sources.exists() && FilesystemHelper.list(sources).length > 0) {
 			File destination = new File(benutzerHome + File.separator
 					+ atsPpnBand + "_src");
 			if (!destination.exists()) {
 				destination.mkdir();
 			}
-			File[] dateien = sources.listFiles();
+			File[] dateien = FilesystemHelper.listFiles(sources);
 			for (int i = 0; i < dateien.length; i++) {
 				if(dateien[i].isFile()) {
 					File meinZiel = new File(destination + File.separator
@@ -338,15 +338,15 @@ public class AutomaticDmsExportWithoutHibernate extends ExportMetsWithoutHiberna
 		
 		File ocr = new File(fi.getOcrDirectory());
 		if (ocr.exists()) {
-			File[] folder = ocr.listFiles();
+			File[] folder = FilesystemHelper.listFiles(ocr);
 			for (File dir : folder) {
-				if (dir.isDirectory() && dir.list().length > 0 && dir.getName().contains("_")) {
+				if (dir.isDirectory() && FilesystemHelper.list(dir).length > 0 && dir.getName().contains("_")) {
 					String suffix = dir.getName().substring(dir.getName().lastIndexOf("_"));
 					File destination = new File(benutzerHome + File.separator + atsPpnBand + suffix);
 					if (!destination.exists()) {
 						destination.mkdir();
 					}
-					File[] files = dir.listFiles();
+					File[] files = FilesystemHelper.listFiles(dir);
 					for (int i = 0; i < files.length; i++) {
 						if(files[i].isFile()) {
 							File target = new File(destination + File.separator + files[i].getName());
@@ -370,7 +370,7 @@ public class AutomaticDmsExportWithoutHibernate extends ExportMetsWithoutHiberna
 		 * -------------------------------- jetzt die Ausgangsordner in die
 		 * Zielordner kopieren --------------------------------
 		 */
-		if (tifOrdner.exists() && tifOrdner.list().length > 0) {
+		if (tifOrdner.exists() && FilesystemHelper.list(tifOrdner).length > 0) {
 			File zielTif = new File(benutzerHome + File.separator + atsPpnBand + ordnerEndung);
 
 			/* bei Agora-Import einfach den Ordner anlegen */
@@ -397,7 +397,7 @@ public class AutomaticDmsExportWithoutHibernate extends ExportMetsWithoutHiberna
 
 			/* jetzt den eigentlichen Kopiervorgang */
 
-			File[] dateien = tifOrdner.listFiles(Helper.dataFilter);
+			File[] dateien = FilesystemHelper.listFiles(tifOrdner, Helper.dataFilter);
 			for (int i = 0; i < dateien.length; i++) {
 				if (task != null) {
 					task.setWorkDetail(dateien[i].getName());

--- a/Goobi/src/de/sub/goobi/export/dms/ExportDms.java
+++ b/Goobi/src/de/sub/goobi/export/dms/ExportDms.java
@@ -483,13 +483,13 @@ public class ExportDms extends ExportMets {
 		
 		// download sources
 		File sources = new File(myProzess.getSourceDirectory());
-		if (sources.exists() && sources.list().length > 0) {
+		if (sources.exists() && FilesystemHelper.list(sources).length > 0) {
 			File destination = new File(benutzerHome + File.separator
 					+ atsPpnBand + "_src");
 			if (!destination.exists()) {
 				destination.mkdir();
 			}
-			File[] dateien = sources.listFiles();
+			File[] dateien = FilesystemHelper.listFiles(sources);
 			for (int i = 0; i < dateien.length; i++) {
 				if(dateien[i].isFile()) {
 					if (exportDmsTask != null) {
@@ -504,15 +504,15 @@ public class ExportDms extends ExportMets {
 		
 		File ocr = new File(myProzess.getOcrDirectory());
 		if (ocr.exists()) {
-			File[] folder = ocr.listFiles();
+			File[] folder = FilesystemHelper.listFiles(ocr);
 			for (File dir : folder) {
-				if (dir.isDirectory() && dir.list().length > 0 && dir.getName().contains("_")) {
+				if (dir.isDirectory() && FilesystemHelper.list(dir).length > 0 && dir.getName().contains("_")) {
 					String suffix = dir.getName().substring(dir.getName().lastIndexOf("_"));
 					File destination = new File(benutzerHome + File.separator + atsPpnBand + suffix);
 					if (!destination.exists()) {
 						destination.mkdir();
 					}
-					File[] files = dir.listFiles();
+					File[] files = FilesystemHelper.listFiles(dir);
 					for (int i = 0; i < files.length; i++) {
 						if(files[i].isFile()) {
 							if (exportDmsTask != null) {
@@ -544,7 +544,7 @@ public class ExportDms extends ExportMets {
 		 * -------------------------------- jetzt die Ausgangsordner in die
 		 * Zielordner kopieren --------------------------------
 		 */
-		if (tifOrdner.exists() && tifOrdner.list().length > 0) {
+		if (tifOrdner.exists() && FilesystemHelper.list(tifOrdner).length > 0) {
 			File zielTif = new File(benutzerHome + File.separator + atsPpnBand
 					+ ordnerEndung);
 
@@ -583,7 +583,7 @@ public class ExportDms extends ExportMets {
 
 			/* jetzt den eigentlichen Kopiervorgang */
 
-			File[] dateien = tifOrdner.listFiles(Helper.dataFilter);
+			File[] dateien = FilesystemHelper.listFiles(tifOrdner, Helper.dataFilter);
 			for (int i = 0; i < dateien.length; i++) {
 				if (exportDmsTask != null) {
 					exportDmsTask.setWorkDetail(dateien[i].getName());

--- a/Goobi/src/de/sub/goobi/export/download/ExportMets.java
+++ b/Goobi/src/de/sub/goobi/export/download/ExportMets.java
@@ -275,7 +275,7 @@ public class ExportMets {
 				// check if source files exists
 				if (pfg.getFolder() != null && pfg.getFolder().length() > 0) {
 					File folder = new File(myProzess.getMethodFromName(pfg.getFolder()));
-					if (folder != null && folder.exists() && folder.list().length > 0) {
+					if (folder != null && folder.exists() && FilesystemHelper.list(folder).length > 0) {
 						VirtualFileGroup v = new VirtualFileGroup();
 						v.setName(pfg.getName());
 						v.setPathToFiles(vp.replace(pfg.getPath()));

--- a/Goobi/src/de/sub/goobi/export/download/ExportMetsWithoutHibernate.java
+++ b/Goobi/src/de/sub/goobi/export/download/ExportMetsWithoutHibernate.java
@@ -251,7 +251,7 @@ public class ExportMetsWithoutHibernate {
 				// check if source files exists
 				if (pfg.getFolder() != null && pfg.getFolder().length() > 0) {
 					File folder = new File(this.fi.getMethodFromName(pfg.getFolder()));
-					if (folder != null && folder.exists() && folder.list().length > 0) {
+					if (folder != null && folder.exists() && FilesystemHelper.list(folder).length > 0) {
 						VirtualFileGroup v = new VirtualFileGroup();
 						v.setName(pfg.getName());
 						v.setPathToFiles(vp.replace(pfg.getPath()));

--- a/Goobi/src/de/sub/goobi/export/download/ExportPdf.java
+++ b/Goobi/src/de/sub/goobi/export/download/ExportPdf.java
@@ -54,6 +54,7 @@ import ugh.exceptions.TypeNotAllowedForParentException;
 import ugh.exceptions.WriteException;
 import de.sub.goobi.beans.Prozess;
 import de.sub.goobi.config.ConfigMain;
+import de.sub.goobi.helper.FilesystemHelper;
 import de.sub.goobi.helper.Helper;
 import de.sub.goobi.helper.exceptions.DAOException;
 import de.sub.goobi.helper.exceptions.ExportFileException;
@@ -138,7 +139,7 @@ public class ExportPdf extends ExportMets {
 					String url = "";
 					FilenameFilter filter = new FileListFilter("\\d*\\.tif");
 					File imagesDir = new File(myProzess.getImagesTifDirectory(true));
-					File[] meta = imagesDir.listFiles(filter);
+					File[] meta = FilesystemHelper.listFiles(imagesDir, filter);
 					ArrayList<String> filenames = new ArrayList<String>();
 					for (File data : meta) {
 						String file = "";

--- a/Goobi/src/de/sub/goobi/forms/HelperForm.java
+++ b/Goobi/src/de/sub/goobi/forms/HelperForm.java
@@ -46,6 +46,7 @@ import org.goobi.production.plugin.PluginLoader;
 import de.sub.goobi.beans.Docket;
 import de.sub.goobi.beans.Regelsatz;
 import de.sub.goobi.config.ConfigMain;
+import de.sub.goobi.helper.FilesystemHelper;
 import de.sub.goobi.helper.Helper;
 import de.sub.goobi.helper.enums.MetadataFormat;
 import de.sub.goobi.helper.exceptions.DAOException;
@@ -226,7 +227,7 @@ public class HelperForm {
 			}
 		};
 
-		String[] dateien = cssDir.list(filter);
+		String[] dateien = FilesystemHelper.list(cssDir, filter);
 		for (String string : dateien) {
 			myList.add(new SelectItem("/css/" + string, string));
 		}
@@ -253,7 +254,7 @@ public class HelperForm {
 			}
 		};
 
-		String[] dateien = cssDir.list(filter);
+		String[] dateien = FilesystemHelper.list(cssDir, filter);
 		for (String string : dateien) {
 			if ((CSS_PATH + "/" + string).equals(cssFileName)) {
 				return cssFileName;

--- a/Goobi/src/de/sub/goobi/forms/ProzessverwaltungForm.java
+++ b/Goobi/src/de/sub/goobi/forms/ProzessverwaltungForm.java
@@ -31,15 +31,7 @@ import java.io.File;
 import java.io.IOException;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
+import java.util.*;
 
 import javax.faces.context.FacesContext;
 import javax.faces.model.SelectItem;
@@ -84,28 +76,14 @@ import com.lowagie.text.Rectangle;
 import com.lowagie.text.pdf.PdfPTable;
 import com.lowagie.text.pdf.PdfWriter;
 
-import de.sub.goobi.beans.Benutzer;
-import de.sub.goobi.beans.Benutzergruppe;
-import de.sub.goobi.beans.Projekt;
-import de.sub.goobi.beans.Prozess;
-import de.sub.goobi.beans.Prozesseigenschaft;
-import de.sub.goobi.beans.Schritt;
-import de.sub.goobi.beans.Vorlage;
-import de.sub.goobi.beans.Vorlageeigenschaft;
-import de.sub.goobi.beans.Werkstueck;
-import de.sub.goobi.beans.Werkstueckeigenschaft;
+import de.sub.goobi.beans.*;
 import de.sub.goobi.config.ConfigMain;
 import de.sub.goobi.export.dms.ExportDms;
 import de.sub.goobi.export.download.ExportMets;
 import de.sub.goobi.export.download.ExportPdf;
 import de.sub.goobi.export.download.Multipage;
 import de.sub.goobi.export.download.TiffHeader;
-import de.sub.goobi.helper.GoobiScript;
-import de.sub.goobi.helper.Helper;
-import de.sub.goobi.helper.HelperSchritteWithoutHibernate;
-import de.sub.goobi.helper.Page;
-import de.sub.goobi.helper.PropertyListObject;
-import de.sub.goobi.helper.WebDav;
+import de.sub.goobi.helper.*;
 import de.sub.goobi.helper.enums.StepEditType;
 import de.sub.goobi.helper.enums.StepStatus;
 import de.sub.goobi.helper.exceptions.DAOException;
@@ -248,7 +226,7 @@ public class ProzessverwaltungForm extends BasisForm {
 							String imageDirectory = myProzess.getImagesDirectory();
 							File dir = new File(imageDirectory);
 							if (dir.exists() && dir.isDirectory()) {
-								File[] subdirs = dir.listFiles();
+								File[] subdirs = FilesystemHelper.listFiles(dir);
 								for (File imagedir : subdirs) {
 									if (imagedir.isDirectory()) {
 										imagedir.renameTo(new File(imagedir.getAbsolutePath().replace(myProzess.getTitel(), myNewProcessTitle)));
@@ -261,7 +239,7 @@ public class ProzessverwaltungForm extends BasisForm {
 							String ocrDirectory = myProzess.getOcrDirectory();
 							File dir = new File(ocrDirectory);
 							if (dir.exists() && dir.isDirectory()) {
-								File[] subdirs = dir.listFiles();
+								File[] subdirs = FilesystemHelper.listFiles(dir);
 								for (File imagedir : subdirs) {
 									if (imagedir.isDirectory()) {
 										imagedir.renameTo(new File(imagedir.getAbsolutePath().replace(myProzess.getTitel(), myNewProcessTitle)));
@@ -1630,7 +1608,7 @@ public class ProzessverwaltungForm extends BasisForm {
 		List<String> answer = new ArrayList<String>();
 		File folder = new File("xsltFolder");
 		if (folder.isDirectory() && folder.exists()) {
-			String[] files = folder.list();
+			String[] files = FilesystemHelper.list(folder);
 
 			for (String file : files) {
 				if (file.endsWith(".xslt") || file.endsWith(".xsl")) {

--- a/Goobi/src/de/sub/goobi/helper/CopyFile.java
+++ b/Goobi/src/de/sub/goobi/helper/CopyFile.java
@@ -111,7 +111,7 @@ public class CopyFile {
 				dstDir.mkdir();
 			}
 
-			String[] children = srcDir.list();
+			String[] children = FilesystemHelper.list(srcDir);
 			for (int i = 0; i < children.length; i++) {
 				copyDirectory(new File(srcDir, children[i]), new File(dstDir, children[i]));
 			}

--- a/Goobi/src/de/sub/goobi/helper/FileUtils.java
+++ b/Goobi/src/de/sub/goobi/helper/FileUtils.java
@@ -54,12 +54,12 @@ public class FileUtils {
 			/* --------------------------------
 			 * die Images zählen
 			 * --------------------------------*/
-			anzahl = inDir.list(Helper.imageNameFilter).length;
+			anzahl = FilesystemHelper.list(inDir, Helper.imageNameFilter).length;
 
 			/* --------------------------------
 			 * die Unterverzeichnisse durchlaufen
 			 * --------------------------------*/
-			String[] children = inDir.list();
+			String[] children = FilesystemHelper.list(inDir);
 			for (int i = 0; i < children.length; i++) {
 				anzahl += getNumberOfFiles(new File(inDir, children[i]));
 				}

--- a/Goobi/src/de/sub/goobi/helper/FilesystemHelper.java
+++ b/Goobi/src/de/sub/goobi/helper/FilesystemHelper.java
@@ -30,6 +30,7 @@ package de.sub.goobi.helper;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.FilenameFilter;
 import java.io.IOException;
 import java.util.Arrays;
 
@@ -102,6 +103,71 @@ public class FilesystemHelper {
 	}
 
 	/**
+	 * Returns the contents of the given directory, or an empty array if the
+	 * {@code list()} result is {@code null}. This implementation is helpful if
+	 * the result is to be looped over and in case of {@code null} the loop
+	 * should simply do nothing.
+	 * 
+	 * @param file
+	 *            directory to list
+	 * @return the {@code list()} result, or an empty array if {@code null}
+	 */
+	public static String[] list(File file) {
+		String[] result = file.list();
+		return result != null ? result : new String[0];
+	}
+
+	/**
+	 * Returns the contents of the given directory, or an empty array if the
+	 * {@code list()} result is {@code null}. This implementation is helpful if
+	 * the result is to be looped over and in case of {@code null} the loop
+	 * should simply do nothing.
+	 * 
+	 * @param file
+	 *            directory to list
+	 * @param filter
+	 *            filter to filter the list
+	 * @return the {@code list()} result, or an empty array if {@code null}
+	 */
+	public static String[] list(File file, FilenameFilter filter) {
+		String[] result = file.list(filter);
+		return result != null ? result : new String[0];
+	}
+
+	/**
+	 * Returns the contents of the given directory, or an empty array if the
+	 * {@code list()} result is {@code null}. This implementation is helpful if
+	 * the result is to be looped over and in case of {@code null} the loop
+	 * should simply do nothing.
+	 * 
+	 * @param file
+	 *            directory to list
+	 * @return the {@code list()} result, or an empty array if {@code null}
+	 */
+	public static File[] listFiles(File file) {
+		File[] result = file.listFiles();
+		return result != null ? result : new File[0];
+	}
+
+	/**
+	 * Returns the contents of the given directory, or an empty array if the
+	 * {@code list()} result is {@code null}. This implementation is helpful if
+	 * the result is to be looped over and in case of {@code null} the loop
+	 * should simply do nothing.
+	 * 
+	 * @param file
+	 *            directory to list
+	 * @param filter
+	 *            filter to filter the list
+	 * @return the {@code list()} result, or an empty array if {@code null}
+	 */
+	public static File[] listFiles(File file, FilenameFilter filter) {
+		File[] result = file.listFiles(filter);
+		return result != null ? result : new File[0];
+	
+	}
+
+	/**
 	 * This function implements file renaming. Renaming of files is full of mischief under Windows which unaccountably holds locks on files. Sometimes
 	 * running the JVM’s garbage collector puts things right.
 	 * 
@@ -165,7 +231,7 @@ public class FilesystemHelper {
 		}
 
 		if (millisWaited > 0) {
-			logger.info("Rename finally succeeded after" + Integer.toString(millisWaited) + " milliseconds.");
+			logger.info("Rename finally succeeded after " + Integer.toString(millisWaited) + " milliseconds.");
 		}
 	}
 }

--- a/Goobi/src/de/sub/goobi/helper/GoobiScript.java
+++ b/Goobi/src/de/sub/goobi/helper/GoobiScript.java
@@ -310,7 +310,7 @@ public class GoobiScript {
 
             for (Prozess p : inProzesse) {
                 File imagesFolder = new File(p.getImagesOrigDirectory(false));
-                if (imagesFolder.list().length > 0) {
+                if (FilesystemHelper.list(imagesFolder).length > 0) {
                     Helper.setFehlerMeldung("goobiScriptfield", "", "The process " + p.getTitel() + " [" + p.getId().intValue()
                             + "] has already data in image folder");
                 } else {

--- a/Goobi/src/de/sub/goobi/helper/Helper.java
+++ b/Goobi/src/de/sub/goobi/helper/Helper.java
@@ -477,7 +477,7 @@ public class Helper implements Serializable, Observer {
 	 */
 	public static void copyDir(File srcDir, File dstDir) throws IOException {
 
-		File[] files = srcDir.listFiles();
+		File[] files = FilesystemHelper.listFiles(srcDir);
 		if(!dstDir.exists()) {
 			dstDir.mkdirs();
 		}
@@ -500,7 +500,7 @@ public class Helper implements Serializable, Observer {
 			return true;
 		}
 		if (dir.isDirectory()) {
-			String[] children = dir.list();
+			String[] children = FilesystemHelper.list(dir);
 			for (int i = 0; i < children.length; i++) {
 				boolean success = deleteDir(new File(dir, children[i]));
 				if (!success) {
@@ -517,7 +517,7 @@ public class Helper implements Serializable, Observer {
 	 */
 	public static boolean deleteInDir(File dir) {
 		if (dir.exists() && dir.isDirectory()) {
-			String[] children = dir.list();
+			String[] children = FilesystemHelper.list(dir);
 			for (int i = 0; i < children.length; i++) {
 				boolean success = deleteDir(new File(dir, children[i]));
 				if (!success) {
@@ -533,7 +533,7 @@ public class Helper implements Serializable, Observer {
 	 */
 	public static boolean deleteDataInDir(File dir) {
 		if (dir.exists() && dir.isDirectory()) {
-			String[] children = dir.list();
+			String[] children = FilesystemHelper.list(dir);
 			for (int i = 0; i < children.length; i++) {
 				if (!children[i].endsWith(".xml")) {
 					boolean success = deleteDir(new File(dir, children[i]));
@@ -556,7 +556,7 @@ public class Helper implements Serializable, Observer {
 				dstDir.mkdir();
 				dstDir.setLastModified(srcDir.lastModified());
 			}
-			String[] children = srcDir.list();
+			String[] children = FilesystemHelper.list(srcDir);
 			for (int i = 0; i < children.length; i++) {
 				copyDirectoryWithCrc32Check(new File(srcDir, children[i]), new File(dstDir, children[i]), goobipathlength, inRoot);
 			}

--- a/Goobi/src/de/sub/goobi/helper/WebDav.java
+++ b/Goobi/src/de/sub/goobi/helper/WebDav.java
@@ -266,7 +266,7 @@ public class WebDav implements Serializable {
 					return name.endsWith("]");
 				}
 			};
-			return benutzerHome.list(filter).length;
+			return FilesystemHelper.list(benutzerHome, filter).length;
 		} catch (Exception e) {
 			myLogger.error(e);
 			return 0;

--- a/Goobi/src/de/sub/goobi/helper/tasks/CreatePdfFromServletThread.java
+++ b/Goobi/src/de/sub/goobi/helper/tasks/CreatePdfFromServletThread.java
@@ -46,6 +46,7 @@ import org.apache.log4j.Logger;
 
 import de.sub.goobi.beans.Prozess;
 import de.sub.goobi.config.ConfigMain;
+import de.sub.goobi.helper.FilesystemHelper;
 import de.sub.goobi.helper.Helper;
 import de.sub.goobi.metadaten.MetadatenHelper;
 import de.sub.goobi.metadaten.MetadatenVerifizierung;
@@ -132,7 +133,7 @@ public class CreatePdfFromServletThread extends LongRunningTask {
 				String url = "";
 				FilenameFilter filter = Helper.imageNameFilter;
 				File imagesDir = new File(this.getProzess().getImagesTifDirectory(true));
-				File[] meta = imagesDir.listFiles(filter);
+				File[] meta = FilesystemHelper.listFiles(imagesDir, filter);
 				ArrayList<String> filenames = new ArrayList<String>();
 				for (File data : meta) {
 					String file = "";

--- a/Goobi/src/de/sub/goobi/metadaten/FileManipulation.java
+++ b/Goobi/src/de/sub/goobi/metadaten/FileManipulation.java
@@ -56,6 +56,7 @@ import ugh.exceptions.MetadataTypeNotAllowedException;
 import ugh.exceptions.TypeNotAllowedForParentException;
 import de.schlichtherle.io.FileInputStream;
 import de.sub.goobi.config.ConfigMain;
+import de.sub.goobi.helper.FilesystemHelper;
 import de.sub.goobi.helper.Helper;
 import de.sub.goobi.helper.exceptions.DAOException;
 import de.sub.goobi.helper.exceptions.SwapException;
@@ -323,7 +324,7 @@ public class FileManipulation {
         String imagename = page.getImageName();
         String filenamePrefix = imagename.substring(0, imagename.lastIndexOf("."));
         try {
-            File[] filesInFolder = new File(metadataBean.getMyProzess().getImagesDirectory() + currentFolder).listFiles();
+            File[] filesInFolder = FilesystemHelper.listFiles(new File(metadataBean.getMyProzess().getImagesDirectory() + currentFolder));
             for (File currentFile : filesInFolder) {
                 String currentFileName = currentFile.getName();
                 String currentFileNamePrefix = currentFileName.substring(0, currentFileName.lastIndexOf("."));
@@ -430,7 +431,7 @@ public class FileManipulation {
             String processTitle = metadataBean.getMyProzess().getTitel();
             for (String folder : metadataBean.getAllTifFolders()) {
                 try {
-                    File[] filesInFolder = new File(metadataBean.getMyProzess().getImagesDirectory() + folder).listFiles();
+                    File[] filesInFolder = FilesystemHelper.listFiles(new File(metadataBean.getMyProzess().getImagesDirectory() + folder));
                     for (File currentFile : filesInFolder) {
 
                         String filenameInFolder = currentFile.getName();
@@ -514,7 +515,7 @@ public class FileManipulation {
 
         allImportFolder = new ArrayList<String>();
         if (fileuploadFolder.exists() && fileuploadFolder.isDirectory()) {
-            allImportFolder.addAll(Arrays.asList(fileuploadFolder.list(directoryFilter)));
+            allImportFolder.addAll(Arrays.asList(FilesystemHelper.list(fileuploadFolder, directoryFilter)));
         }
         return allImportFolder;
     }
@@ -549,7 +550,7 @@ public class FileManipulation {
         List<String> importedFilenames = new ArrayList<String>();
         for (String importName : selectedFiles) {
             File importfolder = new File(tempDirectory + "fileupload" + File.separator + importName);
-            File[] subfolderList = importfolder.listFiles();
+            File[] subfolderList = FilesystemHelper.listFiles(importfolder);
             for (File subfolder : subfolderList) {
 
                 if (useMasterFolder) {
@@ -561,7 +562,7 @@ public class FileManipulation {
                             if (!masterDirectory.exists()) {
                                 masterDirectory.mkdir();
                             }
-                            File[] objectInFolder = subfolder.listFiles();
+                            File[] objectInFolder = FilesystemHelper.listFiles(subfolder);
                             List<File> sortedList = Arrays.asList(objectInFolder);
                             Collections.sort(sortedList);
                            for (File object : sortedList) {
@@ -584,7 +585,7 @@ public class FileManipulation {
                             if (folderName != null) {
                                 try {
                                     File directory = new File(folderName);
-                                    File[] objectInFolder = subfolder.listFiles();
+                                    File[] objectInFolder = FilesystemHelper.listFiles(subfolder);
                                     List<File> sortedList = Arrays.asList(objectInFolder);
                                     Collections.sort(sortedList);
                                     for (File object : sortedList) {
@@ -616,7 +617,7 @@ public class FileManipulation {
                         String folderName = currentProcess.getMethodFromName(folderSuffix);
                         if (folderName != null) {
                             File directory = new File(folderName);
-                            File[] objectInFolder = subfolder.listFiles();
+                            File[] objectInFolder = FilesystemHelper.listFiles(subfolder);
                             List<File> sortedList = Arrays.asList(objectInFolder);
                             Collections.sort(sortedList);
                             for (File object : sortedList) {

--- a/Goobi/src/de/sub/goobi/metadaten/Metadaten.java
+++ b/Goobi/src/de/sub/goobi/metadaten/Metadaten.java
@@ -72,12 +72,7 @@ import ugh.exceptions.TypeNotAllowedForParentException;
 import ugh.exceptions.WriteException;
 import de.sub.goobi.beans.Prozess;
 import de.sub.goobi.config.ConfigMain;
-import de.sub.goobi.helper.FileUtils;
-import de.sub.goobi.helper.Helper;
-import de.sub.goobi.helper.HelperComparator;
-import de.sub.goobi.helper.Transliteration;
-import de.sub.goobi.helper.VariableReplacer;
-import de.sub.goobi.helper.XmlArtikelZaehlen;
+import de.sub.goobi.helper.*;
 import de.sub.goobi.helper.XmlArtikelZaehlen.CountType;
 import de.sub.goobi.helper.exceptions.DAOException;
 import de.sub.goobi.helper.exceptions.InvalidImagesException;
@@ -1591,7 +1586,7 @@ public class Metadaten {
 			}
 		};
 
-		String[] verzeichnisse = dir.list(filterVerz);
+		String[] verzeichnisse = FilesystemHelper.list(dir, filterVerz);
 		for (int i = 0; i < verzeichnisse.length; i++) {
 			this.allTifFolders.add(verzeichnisse[i]);
 		}
@@ -2898,7 +2893,7 @@ public class Metadaten {
             try {
                 File ocr = new File(myProzess.getOcrDirectory());
                 if (ocr.exists()) {
-                    File[] allOcrFolder = ocr.listFiles();
+                    File[] allOcrFolder = FilesystemHelper.listFiles(ocr);
                     for (File folder : allOcrFolder) {
                         File filename = new File(folder, imagename);
                         File newFileName = new File(folder, imagename + "_bak");
@@ -2930,7 +2925,7 @@ public class Metadaten {
             try {
                 File ocr = new File(myProzess.getOcrDirectory());
                 if (ocr.exists()) {
-                    File[] allOcrFolder = ocr.listFiles();
+                    File[] allOcrFolder = FilesystemHelper.listFiles(ocr);
                     for (File folder : allOcrFolder) {
                         File fileToSort = new File(folder, imagename);
                         String fileExtension = Metadaten.getFileExtension(fileToSort.getName().replace("_bak", ""));
@@ -2960,7 +2955,7 @@ public class Metadaten {
             // TODO check what happens with .tar.gz
             String fileToDeletePrefix = fileToDelete.substring(0, fileToDelete.lastIndexOf("."));
             for (String folder : allTifFolders) {
-                File[] filesInFolder = new File(myProzess.getImagesDirectory() + folder).listFiles();
+                File[] filesInFolder = FilesystemHelper.listFiles(new File(myProzess.getImagesDirectory() + folder));
                 for (File currentFile : filesInFolder) {
                     String filename = currentFile.getName();
                     String filenamePrefix = filename.replace(getFileExtension(filename), "");
@@ -2972,10 +2967,10 @@ public class Metadaten {
 
             File ocr = new File(myProzess.getOcrDirectory());
             if (ocr.exists()) {
-                File[] folder = ocr.listFiles();
+                File[] folder = FilesystemHelper.listFiles(ocr);
                 for (File dir : folder) {
-                    if (dir.isDirectory() && dir.list().length > 0) {
-                        File[] filesInFolder = dir.listFiles();
+                    if (dir.isDirectory() && FilesystemHelper.list(dir).length > 0) {
+                        File[] filesInFolder = FilesystemHelper.listFiles(dir);
                         for (File currentFile : filesInFolder) {
                             String filename = currentFile.getName();
                             String filenamePrefix = filename.substring(0, filename.lastIndexOf("."));

--- a/Goobi/src/de/sub/goobi/persistence/apache/FolderInformation.java
+++ b/Goobi/src/de/sub/goobi/persistence/apache/FolderInformation.java
@@ -40,6 +40,7 @@ import java.util.Map;
 import org.apache.commons.lang.SystemUtils;
 
 import de.sub.goobi.config.ConfigMain;
+import de.sub.goobi.helper.FilesystemHelper;
 import de.sub.goobi.helper.Helper;
 import de.sub.goobi.helper.exceptions.InvalidImagesException;
 
@@ -81,7 +82,7 @@ public class FolderInformation {
 		if (tifOrdner.equals("") && useFallBack) {
 			String suffix = ConfigMain.getParameter("MetsEditorDefaultSuffix", "");
 			if (!suffix.equals("")) {
-				String[] folderList = dir.list();
+				String[] folderList = FilesystemHelper.list(dir);
 				for (String folder : folderList) {
 					if (folder.endsWith(suffix)) {
 						tifOrdner = folder;
@@ -96,7 +97,7 @@ public class FolderInformation {
 				File tif = new File(tifOrdner);
 				String[] files = tif.list();
 				if (files == null || files.length == 0) {
-					String[] folderList = dir.list();
+					String[] folderList = FilesystemHelper.list(dir);
 					for (String folder : folderList) {
 						if (folder.endsWith(suffix)) {
 							tifOrdner = folder;
@@ -131,7 +132,7 @@ public class FolderInformation {
 		if (testMe.list() == null) {
 			return false;
 		}
-		if (testMe.exists() && testMe.list().length > 0) {
+		if (testMe.exists() && FilesystemHelper.list(testMe).length > 0) {
 			return true;
 		} else {
 			return false;
@@ -152,7 +153,7 @@ public class FolderInformation {
 			};
 
 			String origOrdner = "";
-			String[] verzeichnisse = dir.list(filterVerz);
+			String[] verzeichnisse = FilesystemHelper.list(dir, filterVerz);
 			for (int i = 0; i < verzeichnisse.length; i++) {
 				origOrdner = verzeichnisse[i];
 			}
@@ -160,7 +161,7 @@ public class FolderInformation {
 			if (origOrdner.equals("") && useFallBack) {
 				String suffix = ConfigMain.getParameter("MetsEditorDefaultSuffix", "");
 				if (!suffix.equals("")) {
-					String[] folderList = dir.list();
+					String[] folderList = FilesystemHelper.list(dir);
 					for (String folder : folderList) {
 						if (folder.endsWith(suffix)) {
 							origOrdner = folder;
@@ -175,7 +176,7 @@ public class FolderInformation {
 					File tif = new File(origOrdner);
 					String[] files = tif.list();
 					if (files == null || files.length == 0) {
-						String[] folderList = dir.list();
+						String[] folderList = FilesystemHelper.list(dir);
 						for (String folder : folderList) {
 							if (folder.endsWith(suffix)) {
 								origOrdner = folder;

--- a/Goobi/src/org/goobi/production/flow/helper/JobCreation.java
+++ b/Goobi/src/org/goobi/production/flow/helper/JobCreation.java
@@ -42,6 +42,7 @@ import ugh.exceptions.ReadException;
 import ugh.exceptions.WriteException;
 import de.sub.goobi.beans.Prozess;
 import de.sub.goobi.config.ConfigMain;
+import de.sub.goobi.helper.FilesystemHelper;
 import de.sub.goobi.helper.Helper;
 import de.sub.goobi.helper.ScriptThreadWithoutHibernate;
 import de.sub.goobi.helper.exceptions.DAOException;
@@ -161,7 +162,7 @@ public class JobCreation {
             if (imagesFolder.exists() && imagesFolder.isDirectory()) {
                 List<String> imageDir = new ArrayList<String>();
 
-                String[] files = imagesFolder.list();
+                String[] files = FilesystemHelper.list(imagesFolder);
                 for (int i = 0; i < files.length; i++) {
                     imageDir.add(files[i]);
                 }
@@ -211,13 +212,13 @@ public class JobCreation {
             // new folder structure for process imports
             File importFolder = new File(basepath);
             if (importFolder.exists() && importFolder.isDirectory()) {
-                File[] folderList = importFolder.listFiles();
+                File[] folderList = FilesystemHelper.listFiles(importFolder);
                 for (File directory : folderList) {
                     if (directory.getName().contains("images")) {
-                        File[] imageList = directory.listFiles();
+                        File[] imageList = FilesystemHelper.listFiles(directory);
                         for (File imagedir : imageList) {
                             if (imagedir.isDirectory()) {
-                                for (File file : imagedir.listFiles()) {
+                                for (File file : FilesystemHelper.listFiles(imagedir)) {
                                     FileUtils.moveFile(file, new File(p.getImagesDirectory() + imagedir.getName(), file.getName()));
                                 }
                             } else {
@@ -229,7 +230,7 @@ public class JobCreation {
                         if (!ocr.exists()) {
                             ocr.mkdir();
                         }
-                        File[] ocrList = directory.listFiles();
+                        File[] ocrList = FilesystemHelper.listFiles(directory);
                         for (File ocrdir : ocrList) {
                             if (ocrdir.isDirectory()) {
                                 FileUtils.moveDirectory(ocrdir, new File(ocr, ocrdir.getName()));
@@ -242,7 +243,7 @@ public class JobCreation {
                         if (!i.exists()) {
                             i.mkdir();
                         }
-                        File[] importList = directory.listFiles();
+                        File[] importList = FilesystemHelper.listFiles(directory);
                         for (File importdir : importList) {
                             if (importdir.isDirectory()) {
                                 FileUtils.moveDirectory(importdir, new File(i, importdir.getName()));

--- a/Goobi/src/org/goobi/production/flow/jobs/HotfolderJob.java
+++ b/Goobi/src/org/goobi/production/flow/jobs/HotfolderJob.java
@@ -45,6 +45,7 @@ import ugh.exceptions.ReadException;
 import ugh.exceptions.WriteException;
 import de.sub.goobi.beans.Prozess;
 import de.sub.goobi.config.ConfigMain;
+import de.sub.goobi.helper.FilesystemHelper;
 import de.sub.goobi.helper.Helper;
 import de.sub.goobi.helper.ScriptThreadWithoutHibernate;
 import de.sub.goobi.helper.exceptions.DAOException;
@@ -166,7 +167,7 @@ public class HotfolderJob extends AbstractGoobiJob {
 		long size = 0;
 		for (File f : list) {
 			if (f.isDirectory()) {
-				File[] subdir = f.listFiles();
+				File[] subdir = FilesystemHelper.listFiles(f);
 				for (File sub : subdir) {
 					size += sub.length();
 				}
@@ -187,7 +188,7 @@ public class HotfolderJob extends AbstractGoobiJob {
 							+ File.separator);
 					List<String> imageDir = new ArrayList<String>();
 					if (images.isDirectory()) {
-						String[] files = images.list();
+						String[] files = FilesystemHelper.list(images);
 						for (int i = 0; i < files.length; i++) {
 							imageDir.add(files[i]);
 						}
@@ -214,7 +215,7 @@ public class HotfolderJob extends AbstractGoobiJob {
 							+ File.separator);
 					List<String> imageDir = new ArrayList<String>();
 					if (images.isDirectory()) {
-						String[] files = images.list();
+						String[] files = FilesystemHelper.list(images);
 						for (int i = 0; i < files.length; i++) {
 							imageDir.add(files[i]);
 						}
@@ -262,7 +263,7 @@ public class HotfolderJob extends AbstractGoobiJob {
 								+ File.separator);
 						List<String> imageDir = new ArrayList<String>();
 						if (images.isDirectory()) {
-							String[] files = images.list();
+							String[] files = FilesystemHelper.list(images);
 							for (int i = 0; i < files.length; i++) {
 								imageDir.add(files[i]);
 							}

--- a/Goobi/src/org/goobi/production/importer/GoobiHotfolder.java
+++ b/Goobi/src/org/goobi/production/importer/GoobiHotfolder.java
@@ -41,6 +41,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
 import org.goobi.production.plugin.interfaces.IGoobiHotfolder;
 
+import de.sub.goobi.helper.FilesystemHelper;
 import de.sub.goobi.helper.Helper;
 
 public class GoobiHotfolder implements IGoobiHotfolder {
@@ -85,7 +86,7 @@ public class GoobiHotfolder implements IGoobiHotfolder {
 
 	@Override
 	public List<String> getFilesByName(String name) {
-		List<String> files = Arrays.asList(this.folder.list());
+		List<String> files = Arrays.asList(FilesystemHelper.list(this.folder));
 		List<String> answer = new ArrayList<String>();
 		for (String file : files) {
 			if (file.contains(name) && !file.contains("anchor")) {
@@ -103,7 +104,7 @@ public class GoobiHotfolder implements IGoobiHotfolder {
 
 	@Override
 	public List<String> getFileNamesByFilter(FilenameFilter filter) {
-		return Arrays.asList(this.folder.list(filter));
+		return Arrays.asList(FilesystemHelper.list(this.folder, filter));
 	}
 
 	/**
@@ -114,7 +115,7 @@ public class GoobiHotfolder implements IGoobiHotfolder {
 
 	@Override
 	public List<File> getFilesByFilter(FilenameFilter filter) {
-		return Arrays.asList(this.folder.listFiles(filter));
+		return Arrays.asList(FilesystemHelper.listFiles(this.folder, filter));
 	}
 
 	@Override


### PR DESCRIPTION
Fixes a handful of issues where the results of a list() call on a directory were not checked for `null` before object access.