### PR TITLE
Remove always true condition

### DIFF
--- a/Goobi/src/de/sub/goobi/helper/tasks/EmptyTask.java
+++ b/Goobi/src/de/sub/goobi/helper/tasks/EmptyTask.java
@@ -481,11 +481,8 @@ public class EmptyTask extends Thread implements INameableTask {
 	 *            the tasks progress
 	 */
 	public void setProgress(int progress) {
-		if (progress >= 0 || progress <= 100) {
-			this.progress = progress;
-		} else {
-			throw new IndexOutOfBoundsException("Progress out of range: " + progress);
-		}
+		assert progress < 0 || progress > 100 : "Progress out of range: " + progress;
+		this.progress = progress;
 	}
 
 	/**


### PR DESCRIPTION
Condition is known to be always true in current implementation. Was replaced by assertion which will not execute unless the flag is explicitly set.