### PR TITLE
Change log level to INFO and truncate overcomplicated message

### DIFF
--- a/Goobi/src/de/sub/goobi/helper/tasks/ExportNewspaperBatchTask.java
+++ b/Goobi/src/de/sub/goobi/helper/tasks/ExportNewspaperBatchTask.java
@@ -619,7 +619,9 @@ public class ExportNewspaperBatchTask extends EmptyTask implements INameableTask
 			try {
 				child.addMetadata(optionalField, identifier);
 			} catch (MetadataTypeNotAllowedException e) {
-				logger.warn(e.getMessage());
+				if(logger.isInfoEnabled()){
+					logger.info(e.getMessage().replaceFirst("^Couldn’t add ([^:]+):", "Couldn’t add optional field $1."));
+				}
 			}
 			
 			Integer rank = null;


### PR DESCRIPTION
If MetadataTypeNotAllowedException is thrown in this place it this is a
case that is intended to happen, because an optional field was tried to
add. If this field is not allowed here, it is just the correct behaviour
of the program not to add it. Since some logging is intended in cases
where an exception is thrown the exception is retargeted to INFO level
to state that the program is functioning correctly.

The error message that was logged is overly detailed for our case:

> Couldn’t add (MetadataType) to (DocStrctType): No corresponding
> MetadataType object in result of DocStruc.getAllMetadataTypes().

Therefore a replacement was put in place to make it more concise:

> Couldn’t add optional field (MetadataType) to (DocStrctType).