### PR TITLE
Add missing call of close method

### DIFF
--- a/Goobi/src/de/sub/goobi/helper/ldap/Ldap.java
+++ b/Goobi/src/de/sub/goobi/helper/ldap/Ldap.java
@@ -565,6 +565,9 @@ public class Ldap {
 				ks.setCertificateEntry("PDC", servercert);
 
 				ks.store(ksos, password);
+
+				certFile2.close();
+				cacertFile.close();
 				ksos.close();
 			} catch (Exception e) {
 				myLogger.error(e);


### PR DESCRIPTION
This fixes warnings from FindBugs.

Signed-off-by: Stefan Weil <sw@weilnetz.de>