### PR TITLE
Fix data copier breaking export

### DIFF
--- a/Goobi/src/de/sub/goobi/metadaten/copier/CopierData.java
+++ b/Goobi/src/de/sub/goobi/metadaten/copier/CopierData.java
@@ -149,6 +149,21 @@ public class CopierData {
 	}
 
 	/**
+	 * Returns the process title.
+	 * 
+	 * @return the process title
+	 */
+	public String getProcessTitle() {
+		if (process instanceof Prozess) {
+			return ((Prozess) process).getTitel();
+		} else if (process instanceof ProcessObject) {
+			return ((ProcessObject) process).getTitle();
+		} else {
+			return String.valueOf(process);
+		}
+	}
+	
+	/**
 	 * Returns a string that textually represents this bean.
 	 * 
 	 * @return a string representation of this object
@@ -156,6 +171,6 @@ public class CopierData {
 	 */
 	@Override
 	public String toString() {
-		return "{fileformat: " + fileformat.toString() + ", process: " + process.toString() + '}';
+		return "{fileformat: " + fileformat.toString() + ", process: " + getProcessTitle() + '}';
 	}
 }

--- a/Goobi/src/de/sub/goobi/metadaten/copier/DataCopier.java
+++ b/Goobi/src/de/sub/goobi/metadaten/copier/DataCopier.java
@@ -42,6 +42,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.apache.commons.configuration.ConfigurationException;
+import org.apache.log4j.Logger;
 
 /**
  * A data copier is a class that can be parameterised to copy data in goobi
@@ -50,6 +51,8 @@ import org.apache.commons.configuration.ConfigurationException;
  * @author Matthias Ronge &lt;matthias.ronge@zeutschel.de&gt;
  */
 public class DataCopier {
+	
+	private static final Logger LOG = Logger.getLogger(DataCopier.class);
 
 	/**
 	 * Holds the rules this data copier can apply to a set of working data.
@@ -82,7 +85,13 @@ public class DataCopier {
 	 */
 	public void process(CopierData data) {
 		for (DataCopyrule rule : rules) {
-			rule.apply(data);
+			try {
+				rule.apply(data);
+			} catch (RuntimeException notApplicable) {
+				if (LOG.isInfoEnabled()) {
+					LOG.info("Rule not applicable for \"" + data.getProcessTitle() + "\", skipped: " + rule);
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
The design idea of data copy rules is that rules that cannot be applied for a certain process are skipped silently. If a rule cannot be applied an exception will be thrown. These exceptions must be caught on a per-rule basis.