### PR TITLE
Remove hardcoded filename from code (FindBugs)

### DIFF
--- a/Goobi/plugins/import/PicaMassImport/de/intranda/goobi/plugins/PicaMassImport.java
+++ b/Goobi/plugins/import/PicaMassImport/de/intranda/goobi/plugins/PicaMassImport.java
@@ -670,7 +670,13 @@ public class PicaMassImport implements IImportPlugin, IPlugin {
 
 	public static void main(String[] args) throws ClassNotFoundException, SQLException, IOException {
 		PicaMassImport pmi = new PicaMassImport();
-		pmi.setFile(new File("/home/robert/workspace-git/PicaMassImportPlugins/example/ppn_Beispiele.xls"));
+		String filename = "ppn_Beispiele.xls";
+		if (args.length == 1) {
+			// A filename was given as argument, for example
+			// /home/robert/workspace-git/PicaMassImportPlugins/example/ppn_Beispiele.xls
+			filename = args[0];
+		}
+		pmi.setFile(new File(filename));
 		List<Record> answer = pmi.generateRecordsFromFile();
 		for (Record r : answer) {
 			System.out.println(r.getData());


### PR DESCRIPTION
Report from FindBugs:
  Code contains a hard coded reference to an absolute pathname

Replace the filename by a local default filename and allow any filename
to be passed as an argument.

Signed-off-by: Stefan Weil <sw@weilnetz.de>