### PR TITLE
Fix: ant test run does not abort on error or failure. 

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -393,7 +393,7 @@
 
     <!-- JUnit tests -->
     <target name="junit" depends="compile-tests" description="Run JUnit tests">
-        <junit printsummary="on" fork="yes" forkmode="once">
+        <junit printsummary="on" fork="yes" forkmode="once" haltonerror="true" haltonfailure="true">
             <classpath refid="test.classpath"/>
             <formatter type="xml" usefile="true"/>
             <batchtest todir="${test.report.dir}">


### PR DESCRIPTION
Fixes return value of `ant test` command too. 

Found while investigating issue #424 .