### PR TITLE
Remove unneeded assignment (fix FindBugs warning)

### DIFF
--- a/Goobi/src/de/sub/goobi/metadaten/Metadaten.java
+++ b/Goobi/src/de/sub/goobi/metadaten/Metadaten.java
@@ -1629,9 +1629,8 @@ public class Metadaten {
 	        myLogger.trace("ocr BildErmitteln");
 	        this.ocrResult = "";
 
-	        List<String> dataList = new ArrayList<String>();
 	        myLogger.trace("dataList");
-	        dataList = this.imagehelper.getImageFiles(mydocument.getPhysicalDocStruct());
+	        List<String> dataList = this.imagehelper.getImageFiles(mydocument.getPhysicalDocStruct());
 	        myLogger.trace("dataList 2");
 	        if (dataList == null || dataList.isEmpty()) {
 	            try {


### PR DESCRIPTION
Report from FindBugs: Dead store to local variable.

Remove the assignment. The assigned value was modified before it was used.

Signed-off-by: Stefan Weil <sw@weilnetz.de>