### PR TITLE
Reactivate search step done by user

### DIFF
--- a/Goobi/newpages/ProzessverwaltungSuche.jsp
+++ b/Goobi/newpages/ProzessverwaltungSuche.jsp
@@ -164,7 +164,7 @@
 														</h:panelGroup>
 													</h:panelGroup>
 													<%-- user --%>
-													<h:outputText value="#{msgs.user}: "/>
+													<h:outputText value="#{msgs.stepDoneByUser}: "/>
 													<h:panelGroup>
 														<h:selectOneMenu value="#{SearchForm.stepdoneuser}">
 															<si:selectItems value="#{SearchForm.user}"

--- a/Goobi/newpages/ProzessverwaltungSuche.jsp
+++ b/Goobi/newpages/ProzessverwaltungSuche.jsp
@@ -164,19 +164,18 @@
 														</h:panelGroup>
 													</h:panelGroup>
 													<%-- user --%>
-													<%-- 
-							<h:outputText value="#{msgs.user}: "/>
-							<h:panelGroup>
-								<h:selectOneMenu value="#{SearchForm.stepdoneuser}">
-										<si:selectItems value="#{SearchForm.user}"
-										var="user" itemLabel="#{user.nachVorname}" itemValue="#{user.login}" />
-								</h:selectOneMenu>
-								<h:selectOneMenu value="#{SearchForm.stepdonetitle}">
-									<si:selectItems value="#{SearchForm.stepTitles}"
-										var="stepTitles" itemLabel="#{stepTitles}" itemValue="#{stepTitles}" />
-								</h:selectOneMenu>
-							</h:panelGroup>
-							--%>
+													<h:outputText value="#{msgs.user}: "/>
+													<h:panelGroup>
+														<h:selectOneMenu value="#{SearchForm.stepdoneuser}">
+															<si:selectItems value="#{SearchForm.user}"
+																var="user" itemLabel="#{user.nachVorname}" itemValue="#{user.login}" />
+														</h:selectOneMenu>
+														<h:selectOneMenu value="#{SearchForm.stepdonetitle}">
+														<si:selectItems value="#{SearchForm.stepTitles}"
+															var="stepTitles" itemLabel="#{stepTitles}" itemValue="#{stepTitles}" />
+														</h:selectOneMenu>
+													</h:panelGroup>
+
 													<%-- process id --%>
 													<h:outputText value="#{msgs.id}: " />
 													<h:inputText value="#{SearchForm.idin}" style="width:690px" />

--- a/Goobi/src/de/sub/goobi/forms/SearchForm.java
+++ b/Goobi/src/de/sub/goobi/forms/SearchForm.java
@@ -178,7 +178,12 @@ public class SearchForm {
 		crit.add(Restrictions.eq("istAktiv", true));
 		crit.addOrder(Order.asc("nachname"));
 		crit.addOrder(Order.asc("vorname"));
-		this.user.addAll(crit.list());
+		try {
+			this.user.addAll(crit.list());
+		} catch (RuntimeException rte) {
+			logger.warn("Catched RuntimeException. Hibernate session maybe corrupted - recreating new hibernate session!");
+		}
+
 	}
 
 	public List<String> getProjects() {

--- a/Goobi/src/messages/messages_de.properties
+++ b/Goobi/src/messages/messages_de.properties
@@ -979,6 +979,7 @@ statusOfVolumes=Status der B\u00E4nde
 statusOffen=Offen
 statusRunterSetzen=Bearbeitungsstatus tiefer setzen
 step=Schritt
+stepDoneByUser=Schritt abgeschlossen von Benutzer
 stepInWorkError=Der Schritt ist nicht mehr f\u00FCr die Bearbeitung offen, wahrscheinlich hat in der Zwischenzeit jemand diesen Schritt angenommen
 stepPlugin=Schritt Plugin
 stepSaveError=Es ist ein Fehler beim Speichern des Schrittes aufgetreten.

--- a/Goobi/src/messages/messages_en.properties
+++ b/Goobi/src/messages/messages_en.properties
@@ -987,6 +987,7 @@ statusOfVolumes=Volume status
 statusOffen=Open
 statusRunterSetzen=Move status down
 step=step
+stepDoneByUser=Step done by user
 stepInWorkError=Someone is already editing this step.
 stepPlugin=Step plugin
 stepSaveError=Step save did not work. Error has been logged.


### PR DESCRIPTION
While debugging an error message

"You can't operate on a closed Connection!!!"

on under other conditions (created a couple of newspaper processes and switched to search form) I got following stack trace

```
java.lang.NullPointerException
	at com.mchange.v2.c3p0.impl.NewProxyConnection.getAutoCommit(NewProxyConnection.java:985)
	at org.hibernate.engine.jdbc.internal.LogicalConnectionImpl.isAutoCommit(LogicalConnectionImpl.java:392)
	at org.hibernate.engine.transaction.internal.TransactionCoordinatorImpl.afterNonTransactionalQuery(TransactionCoordinatorImpl.java:195)
	at org.hibernate.internal.SessionImpl.afterOperation(SessionImpl.java:598)
	at org.hibernate.internal.SessionImpl.list(SessionImpl.java:1630)
	at org.hibernate.internal.CriteriaImpl.list(CriteriaImpl.java:374)
	at de.sub.goobi.forms.SearchForm.(SearchForm.java:181)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:57)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:526)
	at java.lang.Class.newInstance(Class.java:383)
...
```

which lead to an unused user list in search form. After in-house presentation and discussion of this search feature, we decided to make this search feature visible again.