### PR TITLE
Switch to named parameter instead of deprecated positional parameter.

### DIFF
--- a/Goobi/src/de/sub/goobi/forms/LoginForm.java
+++ b/Goobi/src/de/sub/goobi/forms/LoginForm.java
@@ -81,7 +81,7 @@ public class LoginForm {
 			/* prüfen, ob schon ein Benutzer mit dem Login existiert */
 			List<Benutzer> treffer;
 			try {
-				treffer = new BenutzerDAO().search("from Benutzer where login=?", this.login);
+				treffer = new BenutzerDAO().search("from Benutzer where login = :username", "username", this.login);
 			} catch (DAOException e) {
 				Helper.setFehlerMeldung("could not read database", e.getMessage());
 				return "";

--- a/Goobi/src/de/sub/goobi/persistence/BaseDAO.java
+++ b/Goobi/src/de/sub/goobi/persistence/BaseDAO.java
@@ -265,4 +265,23 @@ public abstract class BaseDAO implements Serializable {
 		}
 	}
 
+	/**
+	 * Retrieve list of objects by query string and namend parameter.
+	 *
+	 * @param queryString Query string
+	 * @param namedParameter Name of named parameter
+	 * @param parameter Parameter value
+	 * @return List
+	 * @throws DAOException
+	 */
+	protected List retrieveObjs(String queryString, String namedParameter, String parameter) throws DAOException {
+		try {
+			Session session = Helper.getHibernateSession();
+			Query q = session.createQuery(queryString);
+			q.setString(namedParameter, parameter);
+			return q.list();
+		} catch (HibernateException he) {
+			throw new DAOException(he);
+		}
+	}
 }

--- a/Goobi/src/de/sub/goobi/persistence/BenutzerDAO.java
+++ b/Goobi/src/de/sub/goobi/persistence/BenutzerDAO.java
@@ -86,4 +86,18 @@ public class BenutzerDAO extends BaseDAO {
 	public List<Benutzer> search(String query, String parameter) throws DAOException {
 		return retrieveObjs(query, parameter);
 	}
+
+	/**
+	 * Search for a list of users by a named parameter
+	 *
+	 * @param query Search query
+	 * @param namedParameter Name of named parameter
+	 * @param parameter Parameter value
+	 * @return List<Benutzer>
+	 * @throws DAOException
+	 */
+	@SuppressWarnings("unchecked")
+	public List<Benutzer> search(String query, String namedParameter, String parameter) throws DAOException {
+		return retrieveObjs(query, namedParameter, parameter);
+	}
 }


### PR DESCRIPTION
Remove logged warning message

```
WARN  2016-02-16 09:44:48,983 (HqlSqlWalker.java:generatePositionalParameter:929)
        [DEPRECATION] Encountered positional parameter near line 1, column 46.  Positional parameter are considered deprecated; use named parameters or JPA-style positional parameters instead.
```