### PR TITLE
Remove unneeded null check (fixes FindBugs warning) and optimize code

### DIFF
--- a/Goobi/src/de/sub/goobi/metadaten/Metadaten.java
+++ b/Goobi/src/de/sub/goobi/metadaten/Metadaten.java
@@ -1312,16 +1312,14 @@ public class Metadaten {
 		this.alleSeitenNeu = new MetadatumImpl[zaehler];
 		zaehler = 0;
 		MetadataType mdt = this.myPrefs.getMetadataTypeByName("logicalPageNumber");
-		if (meineListe != null && meineListe.size() > 0) {
-			for (DocStruct mySeitenDocStruct : meineListe) {
-				List<? extends Metadata> mySeitenDocStructMetadaten = mySeitenDocStruct.getAllMetadataByType(mdt);
-				for (Metadata meineSeite : mySeitenDocStructMetadaten) {
-					this.alleSeitenNeu[zaehler] = new MetadatumImpl(meineSeite, zaehler, this.myPrefs, this.myProzess);
-					this.alleSeiten[zaehler] = new SelectItem(String.valueOf(zaehler),
-							MetadatenErmitteln(meineSeite.getDocStruct(), "physPageNumber").trim() + ": " + meineSeite.getValue());
-				}
-				zaehler++;
+		for (DocStruct mySeitenDocStruct : meineListe) {
+			List<? extends Metadata> mySeitenDocStructMetadaten = mySeitenDocStruct.getAllMetadataByType(mdt);
+			for (Metadata meineSeite : mySeitenDocStructMetadaten) {
+				this.alleSeitenNeu[zaehler] = new MetadatumImpl(meineSeite, zaehler, this.myPrefs, this.myProzess);
+				this.alleSeiten[zaehler] = new SelectItem(String.valueOf(zaehler),
+					MetadatenErmitteln(meineSeite.getDocStruct(), "physPageNumber").trim() + ": " + meineSeite.getValue());
 			}
+			zaehler++;
 		}
 	}
 


### PR DESCRIPTION
The local variable meineListe cannot be null.

Re-ordering the assignment for local variable zaehler optimizes the
code a little bit.

Signed-off-by: Stefan Weil <sw@weilnetz.de>