### PR TITLE
Remove two unused functions in class ProzessverwaltungForm

### DIFF
--- a/Goobi/src/de/sub/goobi/forms/ProzessverwaltungForm.java
+++ b/Goobi/src/de/sub/goobi/forms/ProzessverwaltungForm.java
@@ -1617,21 +1617,6 @@ public class ProzessverwaltungForm extends BasisForm {
 		}
 	}
 
-	public String getMyProcessId() {
-		return String.valueOf(this.myProzess.getId());
-	}
-
-	public void setMyProcessId(String id) {
-		try {
-			int myid = new Integer(id);
-			this.myProzess = this.dao.get(myid);
-		} catch (DAOException e) {
-			logger.error(e);
-		} catch (NumberFormatException e) {
-			logger.warn(e);
-		}
-	}
-
 	public List<String> getXsltList() {
 		List<String> answer = new ArrayList<String>();
 		SafeFile folder = new SafeFile("xsltFolder");


### PR DESCRIPTION
A side effect is fixing of this FindBugs warning in setMyProcessId:

Boxing/unboxing to parse a primitive

Signed-off-by: Stefan Weil <sw@weilnetz.de>