### PR TITLE
Change Hibernate schema update to schema validation

### DIFF
--- a/Goobi/config/hibernate.cfg.xml
+++ b/Goobi/config/hibernate.cfg.xml
@@ -65,8 +65,8 @@
 		<property name="show_sql">false</property>
 		<property name="hibernate.bytecode.use_reflection_optimizer">false</property>
 
-		<!-- Update database schema on startup -->
-		<property name="hbm2ddl.auto">update</property>
+		<!-- Validate database schema on startup -->
+		<property name="hbm2ddl.auto">validate</property>
 
 		<!-- Die einzelnen Mappings -->
 		<mapping resource="de/sub/goobi/beans/Batch.hbm.xml"/>

--- a/Goobi/config/hibernate.cfg.xml
+++ b/Goobi/config/hibernate.cfg.xml
@@ -27,9 +27,9 @@
  * exception statement from your version.
  -->
 <!DOCTYPE hibernate-configuration PUBLIC
-        "-//Hibernate/Hibernate Configuration DTD 3.0//EN"
+		"-//Hibernate/Hibernate Configuration DTD 3.0//EN"
 
- "http://www.hibernate.org/dtd/hibernate-configuration-3.0.dtd">
+		"http://www.hibernate.org/dtd/hibernate-configuration-3.0.dtd">
 
 <hibernate-configuration>
 
@@ -54,37 +54,39 @@
 		<property name="hibernate.c3p0.validate">true</property>
 
 		<!-- use the C3P0 connection pool -->
-		<property name="connection.provider_class">org.hibernate.service.jdbc.connections.internal.C3P0ConnectionProvider</property>
+		<property name="connection.provider_class">
+			org.hibernate.service.jdbc.connections.internal.C3P0ConnectionProvider
+		</property>
 
 		<!-- Enable Hibernate's automatic session context management -->
 		<property name="current_session_context_class">managed</property>
-        
+
 		<!-- Don't echo all executed SQL to stdout -->
 		<property name="show_sql">false</property>
 		<property name="hibernate.bytecode.use_reflection_optimizer">false</property>
-		
+
 		<!-- Update database schema on startup -->
- 		<property name="hbm2ddl.auto">update</property> 
-		
+		<property name="hbm2ddl.auto">update</property>
+
 		<!-- Die einzelnen Mappings -->
-		<mapping resource="de/sub/goobi/beans/Batch.hbm.xml" />
-		<mapping resource="de/sub/goobi/beans/Benutzergruppe.hbm.xml" />
-		<mapping resource="de/sub/goobi/beans/Benutzer.hbm.xml" />
-		<mapping resource="de/sub/goobi/beans/Benutzereigenschaft.hbm.xml" />
-		<mapping resource="de/sub/goobi/beans/Docket.hbm.xml" />		
-		<mapping resource="de/sub/goobi/beans/Prozess.hbm.xml" />
-		<mapping resource="de/sub/goobi/beans/Prozesseigenschaft.hbm.xml" />
-		<mapping resource="de/sub/goobi/beans/Schritt.hbm.xml" />
-		<mapping resource="de/sub/goobi/beans/Werkstueck.hbm.xml" />
-		<mapping resource="de/sub/goobi/beans/Werkstueckeigenschaft.hbm.xml" />
-		<mapping resource="de/sub/goobi/beans/Vorlage.hbm.xml" />
-		<mapping resource="de/sub/goobi/beans/Vorlageeigenschaft.hbm.xml" />
-		<mapping resource="de/sub/goobi/beans/Projekt.hbm.xml" />
-		<mapping resource="de/sub/goobi/beans/Regelsatz.hbm.xml" />
-		<mapping resource="de/sub/goobi/beans/LdapGruppe.hbm.xml" />
-		<mapping resource="de/sub/goobi/beans/ProjectFileGroup.hbm.xml" />
-        <mapping resource="de/sub/goobi/beans/HistoryEvent.hbm.xml" />
-        
+		<mapping resource="de/sub/goobi/beans/Batch.hbm.xml"/>
+		<mapping resource="de/sub/goobi/beans/Benutzergruppe.hbm.xml"/>
+		<mapping resource="de/sub/goobi/beans/Benutzer.hbm.xml"/>
+		<mapping resource="de/sub/goobi/beans/Benutzereigenschaft.hbm.xml"/>
+		<mapping resource="de/sub/goobi/beans/Docket.hbm.xml"/>
+		<mapping resource="de/sub/goobi/beans/Prozess.hbm.xml"/>
+		<mapping resource="de/sub/goobi/beans/Prozesseigenschaft.hbm.xml"/>
+		<mapping resource="de/sub/goobi/beans/Schritt.hbm.xml"/>
+		<mapping resource="de/sub/goobi/beans/Werkstueck.hbm.xml"/>
+		<mapping resource="de/sub/goobi/beans/Werkstueckeigenschaft.hbm.xml"/>
+		<mapping resource="de/sub/goobi/beans/Vorlage.hbm.xml"/>
+		<mapping resource="de/sub/goobi/beans/Vorlageeigenschaft.hbm.xml"/>
+		<mapping resource="de/sub/goobi/beans/Projekt.hbm.xml"/>
+		<mapping resource="de/sub/goobi/beans/Regelsatz.hbm.xml"/>
+		<mapping resource="de/sub/goobi/beans/LdapGruppe.hbm.xml"/>
+		<mapping resource="de/sub/goobi/beans/ProjectFileGroup.hbm.xml"/>
+		<mapping resource="de/sub/goobi/beans/HistoryEvent.hbm.xml"/>
+
 	</session-factory>
 
 </hibernate-configuration>

--- a/Goobi/src/de/sub/goobi/beans/Benutzer.hbm.xml
+++ b/Goobi/src/de/sub/goobi/beans/Benutzer.hbm.xml
@@ -43,13 +43,19 @@
 		<property name="login" column="login" type="string"/>
 		<property name="ldaplogin" column="ldaplogin" type="string"/>
 		<property name="passwort" column="passwort" type="string"/>
-		<property name="istAktiv" column="IstAktiv"/>
+		<property name="istAktiv" type="java.lang.Boolean">
+			<column name="IstAktiv" sql-type="bit"/>
+		</property>
 		<property name="isVisible" column="isVisible" type="string"/>
 		<property name="standort" column="Standort" type="string"/>
 		<property name="metadatenSprache" column="metadatensprache" type="string"/>
 		<property name="css" column="css" type="string"/>
-		<property name="mitMassendownload" column="mitMassendownload"/>
-		<property name="confVorgangsdatumAnzeigen" column="confVorgangsdatumAnzeigen"/>
+		<property name="mitMassendownload" type="java.lang.Boolean">
+			<column name="mitMassendownload" sql-type="bit"/>
+		</property>
+		<property name="confVorgangsdatumAnzeigen" type="java.lang.Boolean">
+			<column name="confVorgangsdatumAnzeigen" sql-type="bit"/>
+		</property>
 		<property name="tabellengroesse" column="Tabellengroesse" type="integer"/>
 		<property name="sessiontimeout" column="sessiontimeout" type="integer"/>
 		<many-to-one name="ldapGruppe" class="de.sub.goobi.beans.LdapGruppe" column="ldapgruppenID"/>

--- a/Goobi/src/de/sub/goobi/beans/Benutzereigenschaft.hbm.xml
+++ b/Goobi/src/de/sub/goobi/beans/Benutzereigenschaft.hbm.xml
@@ -39,7 +39,9 @@
 
 		<property name="titel" column="Titel" type="string" />
 		<property name="wert" column="Wert" type="string" />
-		<property name="istObligatorisch" column="IstObligatorisch" />
+		<property name="istObligatorisch" type="java.lang.Boolean">
+			<column name="IstObligatorisch" sql-type="bit"/>
+		</property>
 		<property name="datentyp" column="DatentypenID" type="integer" />
 		<property name="auswahl" column="Auswahl" type="string" />
 		<property name="creationDate" column="creationDate" type="timestamp"/>

--- a/Goobi/src/de/sub/goobi/beans/ProjectFileGroup.hbm.xml
+++ b/Goobi/src/de/sub/goobi/beans/ProjectFileGroup.hbm.xml
@@ -43,7 +43,7 @@
 		<property name="suffix" column="suffix" type="string"/>
 		<property name="folder" column="folder" type="string"/>
 		<property name="previewImage" type="java.lang.Boolean">
-			<column name="previewImage" sql-type="tinyint"/>
+			<column name="previewImage" sql-type="bit"/>
 		</property>
 		<many-to-one name="project" class="de.sub.goobi.beans.Projekt" column="ProjekteID"/>
 				

--- a/Goobi/src/de/sub/goobi/beans/ProjectFileGroup.hbm.xml
+++ b/Goobi/src/de/sub/goobi/beans/ProjectFileGroup.hbm.xml
@@ -42,7 +42,9 @@
 		<property name="mimetype" column="mimetype" type="string"/>
 		<property name="suffix" column="suffix" type="string"/>
 		<property name="folder" column="folder" type="string"/>
-		<property name="previewImage" column="previewImage" type="boolean"/>
+		<property name="previewImage" type="java.lang.Boolean">
+			<column name="previewImage" sql-type="tinyint"/>
+		</property>
 		<many-to-one name="project" class="de.sub.goobi.beans.Projekt" column="ProjekteID"/>
 				
 	</class>

--- a/Goobi/src/de/sub/goobi/beans/Projekt.hbm.xml
+++ b/Goobi/src/de/sub/goobi/beans/Projekt.hbm.xml
@@ -39,13 +39,17 @@
 		
 		<property name="titel" column="Titel" type="string"/>
 		
-		<property name="useDmsImport" column="useDmsImport"/>
+		<property name="useDmsImport" type="java.lang.Boolean">
+			<column name="useDmsImport" sql-type="bit"/>
+		</property>
 		<property name="dmsImportTimeOut" column="dmsImportTimeOut" type="integer"/>
 		<property name="dmsImportRootPath" column="dmsImportRootPath" type="string"/>
 		<property name="dmsImportImagesPath" column="dmsImportImagesPath" type="string"/>
 		<property name="dmsImportSuccessPath" column="dmsImportSuccessPath" type="string"/>
 		<property name="dmsImportErrorPath" column="dmsImportErrorPath" type="string"/>
-		<property name="dmsImportCreateProcessFolderHibernate" column="dmsImportCreateProcessFolder"/>
+		<property name="dmsImportCreateProcessFolderHibernate" type="java.lang.Boolean">
+			<column name="dmsImportCreateProcessFolder" sql-type="bit"/>
+		</property>
 		
 		<!-- 
 		<property name="metsFormatDmsExportHibernate" column="metsFormatDmsExport"/>
@@ -72,7 +76,9 @@
 		<property name="numberOfPages" column="numberOfPages" type="integer"/>
 		<property name="numberOfVolumes" column="numberOfVolumes" type="integer"/>
 		
-		<property name="projectIsArchived" column="projectIsArchived"/>
+		<property name="projectIsArchived" type="java.lang.Boolean">
+			<column name="projectIsArchived" sql-type="bit"/>
+		</property>
 	
 		
 		<set name="filegroups" cascade="all,delete-orphan" inverse="true">

--- a/Goobi/src/de/sub/goobi/beans/Prozess.hbm.xml
+++ b/Goobi/src/de/sub/goobi/beans/Prozess.hbm.xml
@@ -39,9 +39,15 @@
 		
 		<property name="titel" column="Titel" type="string"/>
 		<property name="ausgabename" column="ausgabename" type="string"/>
-		<property name="istTemplate" column="IstTemplate"/>
-		<property name="swappedOutHibernate" column="swappedOut" />
-		<property name="inAuswahllisteAnzeigen" column="inAuswahllisteAnzeigen"/>
+		<property name="istTemplate" type="java.lang.Boolean">
+			<column name="IstTemplate" sql-type="bit"/>
+		</property>
+		<property name="swappedOutHibernate" type="java.lang.Boolean">
+			<column name="swappedOut" sql-type="bit"/>
+		</property>
+		<property name="inAuswahllisteAnzeigen" type="java.lang.Boolean">
+			<column name="inAuswahllisteAnzeigen" sql-type="bit"/>
+		</property>
 		<property name="sortHelperStatus" column="sortHelperStatus" type="string"/>
 		<property name="sortHelperImages" column="sortHelperImages" type="integer"/>
 		<property name="sortHelperArticles" column="sortHelperArticles" type="integer"/>

--- a/Goobi/src/de/sub/goobi/beans/Prozesseigenschaft.hbm.xml
+++ b/Goobi/src/de/sub/goobi/beans/Prozesseigenschaft.hbm.xml
@@ -39,7 +39,9 @@
 
 		<property name="titel" column="Titel" type="string" />
 		<property name="wert" column="Wert" type="text" />
-		<property name="istObligatorisch" column="IstObligatorisch" />
+		<property name="istObligatorisch" type="java.lang.Boolean">
+			<column name="IstObligatorisch" sql-type="bit"/>
+		</property>
 		<property name="datentyp" column="DatentypenID" type="integer" />
 		<property name="auswahl" column="Auswahl" type="string" />
 		<property name="creationDate" column="creationDate" type="timestamp"/>

--- a/Goobi/src/de/sub/goobi/beans/Regelsatz.hbm.xml
+++ b/Goobi/src/de/sub/goobi/beans/Regelsatz.hbm.xml
@@ -39,7 +39,9 @@
 		
 		<property name="titel" column="Titel" type="string"/>
 		<property name="datei" column="Datei" type="string"/>
-		<property name="orderMetadataByRulesetHibernate" column="orderMetadataByRuleset"/>
+		<property name="orderMetadataByRulesetHibernate" type="java.lang.Boolean">
+			<column name="orderMetadataByRuleset" sql-type="bit"/>
+		</property>
 		
 	</class>
 

--- a/Goobi/src/de/sub/goobi/beans/Schritt.hbm.xml
+++ b/Goobi/src/de/sub/goobi/beans/Schritt.hbm.xml
@@ -48,18 +48,40 @@
 		<property name="bearbeitungsende" column="BearbeitungsEnde" type="timestamp"/>
 		<!-- 	<property name="typ" column="Typ" type="integer"/>  -->
 		<property name="homeverzeichnisNutzen" column="homeverzeichnisNutzen" type="short"/>
-		
-		<property name="typMetadaten" column="typMetadaten" />
-		<property name="typAutomatisch" column="typAutomatisch" />
-		<property name="typImportFileUpload" column="typImportFileUpload" />
-		<property name="typExportRus" column="typExportRus" />
-		<property name="typImagesLesen" column="typImagesLesen" />
-		<property name="typImagesSchreiben" column="typImagesSchreiben" />
-		<property name="typExportDMS" column="typExportDMS" />
-		<property name="typBeimAnnehmenModul" column="typBeimAnnehmenModul" />
-		<property name="typBeimAnnehmenAbschliessen" column="typBeimAnnehmenAbschliessen" />
-		<property name="typBeimAnnehmenModulUndAbschliessen" column="typBeimAnnehmenModulUndAbschliessen" />
-		<property name="typScriptStep" column="typScriptStep" type="boolean"/>
+
+		<property name="typMetadaten" type="java.lang.Boolean">
+			<column name="typMetadaten" sql-type="bit"/>
+		</property>
+		<property name="typAutomatisch" type="java.lang.Boolean">
+			<column name="typAutomatisch" sql-type="bit"/>
+		</property>
+		<property name="typImportFileUpload" type="java.lang.Boolean">
+			<column name="typImportFileUpload" sql-type="bit"/>
+		</property>
+		<property name="typExportRus" type="java.lang.Boolean">
+			<column name="typExportRus" sql-type="bit"/>
+		</property>
+		<property name="typImagesLesen" type="java.lang.Boolean">
+			<column name="typImagesLesen" sql-type="bit"/>
+		</property>
+		<property name="typImagesSchreiben" type="java.lang.Boolean">
+			<column name="typImagesSchreiben" sql-type="bit"/>
+		</property>
+		<property name="typExportDMS" type="java.lang.Boolean">
+			<column name="typExportDMS" sql-type="bit"/>
+		</property>
+		<property name="typBeimAnnehmenModul" type="java.lang.Boolean">
+			<column name="typBeimAnnehmenModul" sql-type="bit"/>
+		</property>
+		<property name="typBeimAnnehmenAbschliessen" type="java.lang.Boolean">
+			<column name="typBeimAnnehmenAbschliessen" sql-type="bit"/>
+		</property>
+		<property name="typBeimAnnehmenModulUndAbschliessen" type="java.lang.Boolean">
+			<column name="typBeimAnnehmenModulUndAbschliessen" sql-type="bit"/>
+		</property>
+		<property name="typScriptStep" type="java.lang.Boolean">
+			<column name="typScriptStep" sql-type="bit"/>
+		</property>
 		<property name="scriptname1" column="scriptName1" type="string"/>
 		<property name="typAutomatischScriptpfad" column="typAutomatischScriptpfad" type="string"/>
 		<property name="scriptname2" column="scriptName2" type="string"/>
@@ -70,9 +92,13 @@
 		<property name="typAutomatischScriptpfad4" column="typAutomatischScriptpfad4" type="string"/>
 		<property name="scriptname5" column="scriptName5" type="string"/>
 		<property name="typAutomatischScriptpfad5" column="typAutomatischScriptpfad5" type="string"/>
-		<property name="typBeimAbschliessenVerifizieren" column="typBeimAbschliessenVerifizieren" />
+		<property name="typBeimAbschliessenVerifizieren" type="java.lang.Boolean">
+			<column name="typBeimAbschliessenVerifizieren" sql-type="bit"/>
+		</property>
 		<property name="typModulName" column="typModulName" type="string"/>
-		<property name="batchStep" column="batchStep" type="boolean"  />
+		<property name="batchStep" type="java.lang.Boolean">
+			<column name="batchStep" sql-type="bit"/>
+		</property>
 		
 		<property name="stepPlugin" column="stepPlugin" type="string"/>
 		<property name="validationPlugin" column="validationPlugin" type="string"/>

--- a/Goobi/src/de/sub/goobi/beans/Vorlageeigenschaft.hbm.xml
+++ b/Goobi/src/de/sub/goobi/beans/Vorlageeigenschaft.hbm.xml
@@ -39,7 +39,9 @@
 
 		<property name="titel" column="Titel" type="string" />
 		<property name="wert" column="Wert" type="text" />
-		<property name="istObligatorisch" column="IstObligatorisch" />
+		<property name="istObligatorisch" type="java.lang.Boolean">
+			<column name="IstObligatorisch" sql-type="bit"/>
+		</property>
 		<property name="datentyp" column="DatentypenID" type="integer" />
 		<property name="auswahl" column="Auswahl" type="string" />
 		<property name="creationDate" column="creationDate" type="timestamp"/>

--- a/Goobi/src/de/sub/goobi/beans/Werkstueckeigenschaft.hbm.xml
+++ b/Goobi/src/de/sub/goobi/beans/Werkstueckeigenschaft.hbm.xml
@@ -39,7 +39,9 @@
 
 		<property name="titel" column="Titel" type="string" />
 		<property name="wert" column="Wert" type="text" />
-		<property name="istObligatorisch" column="IstObligatorisch" />
+		<property name="istObligatorisch" type="java.lang.Boolean">
+			<column name="IstObligatorisch" sql-type="bit"/>
+		</property>
 		<property name="datentyp" column="DatentypenID" type="integer" />
 		<property name="auswahl" column="Auswahl" type="string" />
 		<property name="creationDate" column="creationDate" type="timestamp"/>


### PR DESCRIPTION
Up to now it is not possible to run Goobi.Production in productive environments with only Hibernate schema validation. You must Hibernate allow to change your database structure on every initialisation.

This pull request change fix this: you can now run your productive environment without automatic database schema update through Hibernate. You must then update database schema manual. 

But you can still allow Hibernate to update your database schema. For this you must change hibernate property `hbm2ddl.auto` from `validate` to `update`.